### PR TITLE
ref: remove maturin default sum_as_string function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,6 @@ mod types;
 
 const MAX_STACK_DEPTH: u64 = 128;
 
-/// Formats the sum of two numbers as string.
-#[pyfunction]
-fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
-    Ok((a + b).to_string())
-}
-
 #[pyfunction]
 fn parse_profile_chunk(profile: &str) -> PyResult<ProfileChunk> {
     ProfileChunk::from_json_string(profile)
@@ -26,7 +20,6 @@ fn parse_profile_chunk(profile: &str) -> PyResult<ProfileChunk> {
 /// A Python module implemented in Rust.
 #[pymodule]
 fn rust_vroom(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     m.add_function(wrap_pyfunction!(parse_profile_chunk, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
This remove the default sum_as_string function that is automatically created with a new maturin project.