### PR TITLE
fix: remove linux arm from the platform matrix

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -19,5 +19,4 @@ targets:
 requireNames:
   - /^vroomrs-*-macosx_*_x86_64.whl$/
   - /^vroomrs-*-macosx_*_arm64.whl$/
-  - /^vroomrs-*-manylinux_*_aarch64_*_arm64.whl$/
   - /^vroomrs-*-manylinux_*_x86_64.whl$/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
         platform:
           - runner: ubuntu-latest
             target: x86_64
-          - runner: ubuntu-24.04-arm
-            target: aarch64
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`arm64` hosted runners currently do not work in private repositories.

See: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/#how-to-use-the-runners