### PR TITLE
ref: set changelogPolicy to none

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -3,7 +3,7 @@ minVersion: "0.34.1"
 github:
   owner: getsentry
   repo: vroomrs
-changelogPolicy: auto
+changelogPolicy: none
 
 statusProvider:
   name: github


### PR DESCRIPTION
Setting the policy to none.
This can be changed in a second moment once we validated the whole release cycle.