### PR TITLE
feat: add transaction-profiling scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +119,15 @@ name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -353,6 +372,7 @@ checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 name = "vroomrs"
 version = "0.1.4"
 dependencies = [
+ "chrono",
  "fnv_rs",
  "lz4",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ name = "vroomrs"
 crate-type = ["cdylib"]
 
 [dependencies]
+chrono = {version = "0.4.41", default-features = false, features = [
+  "std",
+  "serde",
+] }
 pyo3 = "0.24.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use nodetree::CallTreeFunction;
+use profile::Profile;
 use profile_chunk::ProfileChunk;
 use pyo3::prelude::*;
 
@@ -6,6 +7,7 @@ mod android;
 mod debug_images;
 mod frame;
 mod nodetree;
+mod profile;
 mod profile_chunk;
 mod sample;
 mod types;
@@ -46,6 +48,19 @@ fn profile_chunk_from_json_str(profile: &str, platform: Option<&str>) -> PyResul
     }
 }
 
+#[pyfunction]
+#[pyo3(signature = (profile))]
+fn profile_from_json_str(profile: &str) -> PyResult<Profile> {
+    // match platform {
+    //     Some(platform) => ProfileChunk::from_json_vec_and_platform(profile.as_bytes(), platform)
+    //         .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string())),
+    //     None => ProfileChunk::from_json_vec(profile.as_bytes())
+    //         .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string())),
+    // }
+    Profile::from_json_vec(profile.as_bytes())
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+}
+
 /// Returns a `ProfileChunk` instance from a lz4 encoded profile.
 ///
 /// Arguments
@@ -81,5 +96,6 @@ fn vroomrs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<CallTreeFunction>()?;
     m.add_function(wrap_pyfunction!(profile_chunk_from_json_str, m)?)?;
     m.add_function(wrap_pyfunction!(decompress_profile_chunk, m)?)?;
+    m.add_function(wrap_pyfunction!(profile_from_json_str, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 use nodetree::CallTreeFunction;
-use profile::ProfileChunk;
+use profile_chunk::ProfileChunk;
 use pyo3::prelude::*;
 
 mod android;
 mod debug_images;
 mod frame;
 mod nodetree;
-mod profile;
+mod profile_chunk;
 mod sample;
 mod types;
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,0 +1,35 @@
+use pyo3::pyclass;
+use serde::de::Error;
+
+use crate::{sample::v1::SampleProfile, types::ProfileInterface};
+
+#[pyclass]
+pub struct Profile {
+    pub profile: Box<dyn ProfileInterface + Send + Sync>,
+}
+
+#[derive(serde::Deserialize)]
+struct MinimumProfile {
+    version: Option<String>,
+}
+
+impl Profile {
+    pub(crate) fn from_json_vec(profile: &[u8]) -> Result<Self, serde_json::Error> {
+        let min_prof: MinimumProfile = serde_json::from_slice(profile)?;
+        match min_prof.version {
+            None => {
+                // todo: here instead of throwing an error we'll add support for
+                // android profiles.
+                Err(serde_json::Error::custom(
+                    "todo: add android profile support",
+                ))
+            }
+            Some(_) => {
+                let sample: SampleProfile = serde_json::from_slice(profile)?;
+                Ok(Profile {
+                    profile: Box::new(sample),
+                })
+            }
+        }
+    }
+}

--- a/src/profile_chunk.rs
+++ b/src/profile_chunk.rs
@@ -342,7 +342,7 @@ fn decompress(source: &[u8]) -> Result<Vec<u8>, std::io::Error> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        android::chunk::AndroidChunk, profile::ProfileChunk, sample::v2::SampleChunk,
+        android::chunk::AndroidChunk, profile_chunk::ProfileChunk, sample::v2::SampleChunk,
         types::Platform,
     };
 

--- a/src/sample/mod.rs
+++ b/src/sample/mod.rs
@@ -1,7 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+pub mod v1;
 pub mod v2;
 
 #[derive(Debug)]
 pub enum SampleError {
     InvalidStackId,
     InvalidFrameId,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct ThreadMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    priority: Option<i32>,
 }

--- a/src/sample/v1.rs
+++ b/src/sample/v1.rs
@@ -1,0 +1,150 @@
+use crate::{
+    frame::Frame,
+    types::{self, ClientSDK, DebugMeta, Platform, ProfileInterface},
+};
+
+use super::ThreadMetadata;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub struct OSMetadata {
+    name: String,
+    version: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    build_number: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Measurement {
+    unit: String,
+    values: Vec<MeasurementValue>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct MeasurementValue {
+    elapsed_since_start_ns: u64,
+    value: f64,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Device {
+    architecture: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    classification: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    locale: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    manufacturer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct RuntimeMetadata {
+    name: String,
+    version: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct QueueMetadata {
+    label: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Sample {
+    stack_id: usize,
+    thread_id: u64,
+    elapsed_since_start_ns: u64,
+
+    // cocoa only
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    queue_address: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sate: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Profile {
+    frames: Vec<Frame>,
+    queue_metadata: HashMap<String, QueueMetadata>,
+    samples: Vec<Sample>,
+    stacks: Vec<Vec<usize>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    thread_metadata: Option<HashMap<String, ThreadMetadata>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+pub struct SampleProfile {
+    pub client_sdk: Option<ClientSDK>,
+
+    #[serde(default, skip_serializing_if = "DebugMeta::is_empty")]
+    pub debug_meta: DebugMeta,
+
+    device: Device,
+
+    pub environment: Option<String>,
+
+    pub event_id: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub measurements: Option<HashMap<String, Measurement>>,
+
+    pub os: OSMetadata,
+
+    pub organization_id: u64,
+
+    pub platform: Platform,
+
+    pub project_id: u64,
+
+    pub received: f64,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release: Option<String>,
+
+    pub retention_days: i32,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runtime: Option<RuntimeMetadata>,
+
+    timestamp: DateTime<Utc>,
+
+    transaction: types::Transaction,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transaction_metadata: Option<types::TransactionMetadata>,
+
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    transaction_tags: HashMap<String, String>,
+
+    version: String,
+}
+
+impl ProfileInterface for SampleProfile {}
+
+#[cfg(test)]
+mod tests {
+
+    use serde_path_to_error::Error;
+
+    use crate::sample::v1::SampleProfile;
+
+    #[test]
+    fn test_sample_format_v1_cocoa() {
+        let payload = include_bytes!("../../tests/fixtures/sample/v1/valid_cocoa.json");
+        let d = &mut serde_json::Deserializer::from_slice(payload);
+        let r: Result<SampleProfile, Error<_>> = serde_path_to_error::deserialize(d);
+        assert!(r.is_ok(), "{:#?}", r)
+    }
+
+    #[test]
+    fn test_sample_format_v1_python() {
+        let payload = include_bytes!("../../tests/fixtures/sample/v1/valid_python.json");
+        let d = &mut serde_json::Deserializer::from_slice(payload);
+        let r: Result<SampleProfile, Error<_>> = serde_path_to_error::deserialize(d);
+        assert!(r.is_ok(), "{:#?}", r)
+    }
+}

--- a/src/sample/v2.rs
+++ b/src/sample/v2.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::hash::Hasher;
 use std::rc::Rc;
 
-use super::SampleError;
+use super::{SampleError, ThreadMetadata};
 use crate::frame::Frame;
 use crate::nodetree::Node;
 use crate::types::{CallTreeError, CallTreesStr, ChunkInterface};
@@ -46,14 +46,6 @@ pub struct SampleChunk {
     // `measurements` contains CPU/memory measurements we do during the capture of the chunk.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub measurements: Option<serde_json::Value>,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct ThreadMetadata {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    priority: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use chrono::{DateTime, Utc};
+
 use pyo3::exceptions::PyValueError;
 use pyo3::{pyclass, PyErr};
 use serde::{Deserialize, Serialize};
@@ -157,3 +159,57 @@ pub trait ChunkInterface {
 
     fn as_any(&self) -> &dyn Any;
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub struct Transaction {
+    active_thread_id: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    duration_ns: Option<u64>,
+    id: String,
+    name: String,
+    trace_id: String,
+    segment_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct TransactionMetadata {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "app.identifier"
+    )]
+    app_identifier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    dist: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    environment: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "http.method"
+    )]
+    http_method: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    release: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    transaction: Option<String>,
+    #[serde(rename = "transaction.end")]
+    transaction_end: DateTime<Utc>,
+    #[serde(rename = "transaction.start")]
+    transaction_start: DateTime<Utc>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "transaction.op"
+    )]
+    transaction_op: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "transaction.status"
+    )]
+    transaction_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    segment_id: Option<String>,
+}
+pub trait ProfileInterface {}

--- a/tests/fixtures/sample/v1/valid_cocoa.json
+++ b/tests/fixtures/sample/v1/valid_cocoa.json
@@ -1,0 +1,492 @@
+{
+    "client_sdk": {
+        "name": "sentry.cocoa",
+        "version": "8.51.0"
+    },
+    "debug_meta": {
+        "images": [
+            {
+                "code_file": "/Users/runner/Library/Developer/CoreSimulator/Devices/1FFD46C1-E610-4708-A4FB-F98F0C844C00/data/Containers/Bundle/Application/13E59875-810F-4075-AC64-14486F0B4F6F/iOS-Swift.app/iOS-Swift",
+                "debug_id": "f156cb0e-f47a-3103-a137-bf8d616e12a1",
+                "debug_status": "unused",
+                "features": {
+                    "has_debug_info": false,
+                    "has_sources": false,
+                    "has_symbols": false,
+                    "has_unwind_info": false
+                },
+                "image_addr": "0x102dc8000",
+                "image_size": 16384,
+                "image_vmaddr": "0x100000000",
+                "type": "macho"
+            },
+            {
+                "arch": "arm64",
+                "code_file": "/usr/lib/system/libsystem_platform.dylib",
+                "debug_id": "98803d0c-942b-350b-baf1-4879fd637409",
+                "debug_status": "found",
+                "features": {
+                    "has_debug_info": false,
+                    "has_sources": false,
+                    "has_symbols": true,
+                    "has_unwind_info": true
+                },
+                "image_addr": "0x102de0000",
+                "image_size": 32768,
+                "type": "macho"
+            },
+            {
+                "arch": "arm64",
+                "code_file": "/usr/lib/system/libsystem_kernel.dylib",
+                "debug_id": "02dd445e-88c2-3ac8-979a-cf2b39185f71",
+                "debug_status": "found",
+                "features": {
+                    "has_debug_info": false,
+                    "has_sources": false,
+                    "has_symbols": true,
+                    "has_unwind_info": true
+                },
+                "image_addr": "0x102f80000",
+                "image_size": 245760,
+                "type": "macho"
+            },
+            {
+                "arch": "arm64",
+                "code_file": "/usr/lib/system/libsystem_pthread.dylib",
+                "debug_id": "e4d4a6eb-1bf6-3f43-a21d-d042f2771dc4",
+                "debug_status": "found",
+                "features": {
+                    "has_debug_info": false,
+                    "has_sources": false,
+                    "has_symbols": true,
+                    "has_unwind_info": true
+                },
+                "image_addr": "0x102fec000",
+                "image_size": 65536,
+                "type": "macho"
+            },
+            {
+                "code_file": "/Library/Developer/CoreSimulator/Volumes/iOS_21F79/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libobjc-trampolines.dylib",
+                "debug_id": "c6ef2cc0-8ca9-3a69-a525-91bec719ddfc",
+                "debug_status": "unused",
+                "features": {
+                    "has_debug_info": false,
+                    "has_sources": false,
+                    "has_symbols": false,
+                    "has_unwind_info": false
+                },
+                "image_addr": "0x10311c000",
+                "image_size": 49152,
+                "type": "macho"
+            }
+        ]
+    },
+    "device": {
+        "architecture": "arm64e",
+        "classification": "high",
+        "locale": "en_US",
+        "manufacturer": "Apple",
+        "model": "iPhone16,1"
+    },
+    "environment": "simulator",
+    "event_id": "7621eb0005654725b30eb063406a0e16",
+    "measurements": {
+        "cpu_energy_usage": {
+            "unit": "nanojoule",
+            "values": [
+                {
+                    "elapsed_since_start_ns": 350203333,
+                    "value": 2302412
+                },
+                {
+                    "elapsed_since_start_ns": 421402708,
+                    "value": 1523192
+                },
+                {
+                    "elapsed_since_start_ns": 530712458,
+                    "value": 2499779
+                },
+                {
+                    "elapsed_since_start_ns": 625714417,
+                    "value": 2324960
+                },
+                {
+                    "elapsed_since_start_ns": 732791042,
+                    "value": 2627087
+                },
+                {
+                    "elapsed_since_start_ns": 833298083,
+                    "value": 2447555
+                },
+                {
+                    "elapsed_since_start_ns": 918256750,
+                    "value": 2070586
+                },
+                {
+                    "elapsed_since_start_ns": 1031158500,
+                    "value": 2757938
+                },
+                {
+                    "elapsed_since_start_ns": 1118730125,
+                    "value": 2138419
+                },
+                {
+                    "elapsed_since_start_ns": 1221099667,
+                    "value": 2712393
+                },
+                {
+                    "elapsed_since_start_ns": 1327475167,
+                    "value": 2710580
+                },
+                {
+                    "elapsed_since_start_ns": 1407320958,
+                    "value": 3178190
+                },
+                {
+                    "elapsed_since_start_ns": 1487562833,
+                    "value": 2523515
+                }
+            ]
+        },
+        "cpu_usage": {
+            "unit": "percent",
+            "values": [
+                {
+                    "elapsed_since_start_ns": 256065292,
+                    "value": 161
+                },
+                {
+                    "elapsed_since_start_ns": 350191833,
+                    "value": 226.66665649414065
+                },
+                {
+                    "elapsed_since_start_ns": 421394042,
+                    "value": 262
+                },
+                {
+                    "elapsed_since_start_ns": 530702375,
+                    "value": 262
+                },
+                {
+                    "elapsed_since_start_ns": 625703208,
+                    "value": 280.66668701171875
+                },
+                {
+                    "elapsed_since_start_ns": 732780583,
+                    "value": 307.3333435058594
+                },
+                {
+                    "elapsed_since_start_ns": 833283250,
+                    "value": 315
+                },
+                {
+                    "elapsed_since_start_ns": 918245083,
+                    "value": 327
+                },
+                {
+                    "elapsed_since_start_ns": 1031151292,
+                    "value": 327
+                },
+                {
+                    "elapsed_since_start_ns": 1118721958,
+                    "value": 333.66668701171875
+                },
+                {
+                    "elapsed_since_start_ns": 1221084000,
+                    "value": 337
+                },
+                {
+                    "elapsed_since_start_ns": 1327463417,
+                    "value": 337.0000305175781
+                },
+                {
+                    "elapsed_since_start_ns": 1407309833,
+                    "value": 393.00003051757807
+                },
+                {
+                    "elapsed_since_start_ns": 1487552250,
+                    "value": 393.00003051757807
+                }
+            ]
+        },
+        "memory_footprint": {
+            "unit": "byte",
+            "values": [
+                {
+                    "elapsed_since_start_ns": 256078333,
+                    "value": 15963584
+                },
+                {
+                    "elapsed_since_start_ns": 350199417,
+                    "value": 17470912
+                },
+                {
+                    "elapsed_since_start_ns": 421399792,
+                    "value": 18486720
+                },
+                {
+                    "elapsed_since_start_ns": 530709542,
+                    "value": 20092352
+                },
+                {
+                    "elapsed_since_start_ns": 625711583,
+                    "value": 21632448
+                },
+                {
+                    "elapsed_since_start_ns": 732788208,
+                    "value": 23369152
+                },
+                {
+                    "elapsed_since_start_ns": 833294792,
+                    "value": 24974784
+                },
+                {
+                    "elapsed_since_start_ns": 918253833,
+                    "value": 26383872
+                },
+                {
+                    "elapsed_since_start_ns": 1031155917,
+                    "value": 28235200
+                },
+                {
+                    "elapsed_since_start_ns": 1118727125,
+                    "value": 29693376
+                },
+                {
+                    "elapsed_since_start_ns": 1221094458,
+                    "value": 12130048
+                },
+                {
+                    "elapsed_since_start_ns": 1327469125,
+                    "value": 16963392
+                },
+                {
+                    "elapsed_since_start_ns": 1407317625,
+                    "value": 19060864
+                },
+                {
+                    "elapsed_since_start_ns": 1487559417,
+                    "value": 21289088
+                }
+            ]
+        }
+    },
+    "os": {
+        "build_number": "24E263",
+        "name": "iOS",
+        "version": "17.5"
+    },
+    "options": null,
+    "organization_id": 447951,
+    "platform": "cocoa",
+    "project_id": 5428557,
+    "received": 1747725357,
+    "release": "io.sentry.sample.iOS-Swift@8.51.0+1",
+    "retention_days": 90,
+    "runtime": {
+        "name": "",
+        "version": ""
+    },
+    "sampled": true,
+    "timestamp": "2025-05-20T06:36:46.395Z",
+    "profile": {
+        "frames": [
+            {
+                "data": {},
+                "function": "CFStringCreateMutable",
+                "in_app": false,
+                "instruction_addr": "0x18043318c",
+                "package": "/Library/Developer/CoreSimulator/Volumes/iOS_21F79/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.5.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+                "status": "symbolicated",
+                "sym_addr": "0x180433054",
+                "symbol": "CFStringCreateMutable",
+                "platform": "cocoa"
+            },
+            {
+                "data": {},
+                "function": "-[__NSCFString appendFormat:]",
+                "in_app": false,
+                "instruction_addr": "0x1803e5880",
+                "package": "/Library/Developer/CoreSimulator/Volumes/iOS_21F79/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.5.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+                "status": "symbolicated",
+                "sym_addr": "0x1803e581c",
+                "symbol": "-[__NSCFString appendFormat:]",
+                "platform": "cocoa"
+            },
+            {
+                "data": {},
+                "function": "+[NSObject(SentryAppSetup) sentry_slowLoadWork]",
+                "in_app": true,
+                "instruction_addr": "0x1037ce128",
+                "package": "/Users/runner/Library/Developer/CoreSimulator/Devices/1FFD46C1-E610-4708-A4FB-F98F0C844C00/data/Containers/Bundle/Application/13E59875-810F-4075-AC64-14486F0B4F6F/iOS-Swift.app/iOS-Swift.debug.dylib",
+                "status": "missing",
+                "symbol": "+[NSObject(SentryAppSetup) sentry_slowLoadWork]",
+                "platform": "cocoa"
+            },
+            {
+                "data": {},
+                "function": "+[NSObject(SentryAppSetup) load]",
+                "in_app": true,
+                "instruction_addr": "0x1037ce058",
+                "package": "/Users/runner/Library/Developer/CoreSimulator/Devices/1FFD46C1-E610-4708-A4FB-F98F0C844C00/data/Containers/Bundle/Application/13E59875-810F-4075-AC64-14486F0B4F6F/iOS-Swift.app/iOS-Swift.debug.dylib",
+                "status": "missing",
+                "symbol": "+[NSObject(SentryAppSetup) load]",
+                "platform": "cocoa"
+            },
+            {
+                "data": {},
+                "function": "load_images",
+                "in_app": false,
+                "instruction_addr": "0x18006efb4",
+                "package": "/Library/Developer/CoreSimulator/Volumes/iOS_21F79/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.5.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libobjc.A.dylib",
+                "status": "symbolicated",
+                "sym_addr": "0x18006ec58",
+                "symbol": "load_images",
+                "platform": "cocoa"
+            },
+            {
+                "data": {},
+                "function": "dyld4::RuntimeState::notifyObjCInit(dyld4::Loader const*)",
+                "in_app": false,
+                "instruction_addr": "0x10306bd34",
+                "status": "unknown_image",
+                "symbol": "_ZN5dyld412RuntimeState14notifyObjCInitEPKNS_6LoaderE",
+                "platform": "cocoa"
+            },
+            {
+                "data": {},
+                "function": "dyld4::Loader::runInitializersBottomUp(dyld4::RuntimeState\u0026, dyld3::Array\u003cdyld4::Loader const*\u003e\u0026) const",
+                "in_app": false,
+                "instruction_addr": "0x10307138c",
+                "status": "unknown_image",
+                "symbol": "_ZNK5dyld46Loader23runInitializersBottomUpERNS_12RuntimeStateERN5dyld35ArrayIPKS0_EE",
+                "platform": "cocoa"
+            }
+
+        ],
+        "queue_metadata": null,
+        "samples": [
+            {
+                "elapsed_since_start_ns": 97586875,
+                "stack_id": 0,
+                "thread_id": 259
+            },
+            {
+                "elapsed_since_start_ns": 109500875,
+                "stack_id": 2,
+                "thread_id": 259
+            },
+            {
+                "elapsed_since_start_ns": 121515917,
+                "stack_id": 3,
+                "thread_id": 259
+            },
+            {
+                "elapsed_since_start_ns": 133395875,
+                "stack_id": 4,
+                "thread_id": 259
+            }
+        ],
+        "stacks": [
+            [
+                510,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+            ],
+            [],
+            [
+                511,
+                19,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+            ],
+            [
+                512,
+                21,
+                22,
+                23,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+            ]
+        ],
+        "thread_metadata": {
+            "16131": {
+                "priority": 31
+            },
+            "259": {
+                "name": "main",
+                "priority": 31
+            },
+            "5635": {
+                "priority": 31
+            },
+            "8747": {
+                "priority": 31
+            }
+        }
+    },
+    "transaction": {
+        "active_thread_id": 259,
+        "id": "748874cc7cea4178ba4cd3dd9dad3c1b",
+        "name": "launch",
+        "trace_id": "5b4e63e7d65a46faa8438356beedba37",
+        "segment_id": "8be23b3c2acf4233"
+    },
+    "transaction_metadata": {
+        "app.identifier": "io.sentry.sample.iOS-Swift",
+        "dist": "1",
+        "environment": "simulator",
+        "release": "io.sentry.sample.iOS-Swift@8.51.0+1",
+        "transaction": "launch",
+        "transaction.end": "2025-05-20T06:36:47.881627082Z",
+        "transaction.op": "app.lifecycle",
+        "transaction.start": "2025-05-20T06:36:46.394814014Z",
+        "transaction.status": "ok",
+        "segment_id": "8be23b3c2acf4233"
+    },
+    "transaction_tags": {
+        "device.class": "3",
+        "git-branch-name": "main",
+        "git-commit-hash": "e70c3aa-dirty",
+        "language": "swift",
+        "ui-test-name": "-[ProfilingUITests testAppLaunchesWithTraceProfiler]"
+    },
+    "version": "1"
+}

--- a/tests/fixtures/sample/v1/valid_python.json
+++ b/tests/fixtures/sample/v1/valid_python.json
@@ -1,0 +1,181 @@
+{
+    "client_sdk": {
+        "name": "sentry.python.django",
+        "version": "2.27.0"
+    },
+    "debug_meta": {},
+    "device": {
+        "architecture": "x86_64",
+        "classification": "",
+        "locale": "",
+        "manufacturer": "",
+        "model": ""
+    },
+    "environment": "de",
+    "event_id": "ba06cbd52dfe4d5699958cbe1cb0acc8",
+    "os": {
+        "build_number": "",
+        "name": "Linux",
+        "version": "6.6.72+"
+    },
+    "options": null,
+    "organization_id": 1,
+    "platform": "python",
+    "project_id": 1,
+    "received": 1747725357,
+    "release": "backend@0123ab0f39d0c4b61e34fb5ecfb911e7b0b0412c",
+    "retention_days": 90,
+    "runtime": {
+        "name": "CPython",
+        "version": "3.13.1"
+    },
+    "sampled": true,
+    "timestamp": "2025-05-19T13:47:00.482107Z",
+    "profile": {
+        "frames": [
+            {
+                "data": {},
+                "filename": "concurrent/futures/thread.py",
+                "function": "_worker",
+                "in_app": false,
+                "lineno": 90,
+                "module": "concurrent.futures.thread",
+                "abs_path": "/usr/local/lib/python3.13/concurrent/futures/thread.py",
+                "platform": "python"
+            },
+            {
+                "data": {},
+                "filename": "threading.py",
+                "function": "Thread.run",
+                "in_app": false,
+                "lineno": 992,
+                "module": "threading",
+                "abs_path": "/usr/local/lib/python3.13/threading.py",
+                "platform": "python"
+            },
+            {
+                "data": {},
+                "filename": "sentry_sdk/integrations/threading.py",
+                "function": "_wrap_run.\u003clocals\u003e.run.\u003clocals\u003e._run_old_run_func",
+                "in_app": false,
+                "lineno": 123,
+                "module": "sentry_sdk.integrations.threading",
+                "abs_path": "/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/threading.py",
+                "platform": "python"
+            },
+            {
+                "data": {},
+                "filename": "sentry_sdk/integrations/threading.py",
+                "function": "_wrap_run.\u003clocals\u003e.run",
+                "in_app": false,
+                "lineno": 130,
+                "module": "sentry_sdk.integrations.threading",
+                "abs_path": "/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/threading.py",
+                "platform": "python"
+            }
+        ],
+        "queue_metadata": null,
+        "samples": [
+            {
+                "elapsed_since_start_ns": 1791821,
+                "stack_id": 0,
+                "thread_id": 133875472791232
+            },
+            {
+                "elapsed_since_start_ns": 1791821,
+                "stack_id": 0,
+                "thread_id": 133875895346880
+            },
+            {
+                "elapsed_since_start_ns": 1791821,
+                "stack_id": 0,
+                "thread_id": 133875903739584
+            },
+            {
+                "elapsed_since_start_ns": 1791821,
+                "stack_id": 0,
+                "thread_id": 133875912132288
+            }
+        ],
+        "stacks": [
+            [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            [
+                6,
+                7,
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            [
+                8,
+                9,
+                10,
+                1,
+                2,
+                3,
+                4,
+                5
+            ]
+        ],
+        "thread_metadata": {
+            "133875472791232": {
+                "name": "ThreadPoolExecutor-2_1"
+            },
+            "133875895346880": {
+                "name": "ThreadPoolExecutor-1_9"
+            },
+            "133875903739584": {
+                "name": "ThreadPoolExecutor-1_8"
+            }
+        }
+    },
+    "transaction": {
+        "active_thread_id": 133877343446720,
+        "id": "94ca1318dfba4b3991e5207ef0f2855f",
+        "name": "/api/0/organizations/{organization_id_or_slug}/events/",
+        "trace_id": "b6162ea338494ae8b954ada6504beb38",
+        "segment_id": "9d65e7f26086b032"
+    },
+    "transaction_metadata": {
+        "environment": "de",
+        "http.method": "GET",
+        "release": "backend@0123ab0f39d0c4b61e34fb5ecfb911e7b0b0412c",
+        "transaction": "/api/0/organizations/{organization_id_or_slug}/events/",
+        "transaction.end": "2025-05-19T13:47:00.802803039Z",
+        "transaction.op": "http.server",
+        "transaction.start": "2025-05-19T13:47:00.482106924Z",
+        "transaction.status": "ok",
+        "segment_id": "9d65e7f26086b032"
+    },
+    "transaction_tags": {
+        "http.referer": "https://telemetry-experience.sentry.io/",
+        "http.status_code": "200",
+        "organization": "4509089275772928",
+        "organization.slug": "telemetry-experience",
+        "performance.metrics_enhanced": "False",
+        "query.dataset": "spans",
+        "query.num_projects": "1",
+        "query.num_projects.grouped": "1",
+        "query.per_page": "10",
+        "query.per_page.grouped": "\u003c50",
+        "query.period": "604800",
+        "query.period.grouped": "\u003c=7d",
+        "query.sampling_mode": "NORMAL",
+        "query.storage_meta.tier": "0",
+        "server_name": "getsentry-web-default-profiling-production-canary-79fdb8d4wkgh6",
+        "spans_over_limit": "False",
+        "subscription.is-enterprise": "0",
+        "subscription.is-paid": "1",
+        "subscription.plan": "am3_team"
+    },
+    "version": "1"
+}


### PR DESCRIPTION
This PR add the scaffolding for legacy transaction-profiling support.

It includes the definition of the sample profile v1 as well. Android will be added in a separate PR.