### PR TITLE
feat: add utilities to compress and decompress transaction-profiles

### DIFF
--- a/src/android/profile.rs
+++ b/src/android/profile.rs
@@ -89,6 +89,15 @@ impl ProfileInterface for AndroidProfile {
     fn get_platform(&self) -> Platform {
         self.platform
     }
+
+    /// Serialize the given data structure as a JSON byte vector.
+    fn to_json_vec(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(&self)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod profile;
 mod profile_chunk;
 mod sample;
 mod types;
+mod utils;
 
 const MAX_STACK_DEPTH: u64 = 128;
 
@@ -88,6 +89,12 @@ fn decompress_profile_chunk(profile: &[u8]) -> PyResult<ProfileChunk> {
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
 }
 
+#[pyfunction]
+fn decompress_profile(profile: &[u8]) -> PyResult<Profile> {
+    Profile::decompress(profile)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+}
+
 #[pymodule]
 fn vroomrs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ProfileChunk>()?;
@@ -95,5 +102,6 @@ fn vroomrs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(profile_chunk_from_json_str, m)?)?;
     m.add_function(wrap_pyfunction!(decompress_profile_chunk, m)?)?;
     m.add_function(wrap_pyfunction!(profile_from_json_str, m)?)?;
+    m.add_function(wrap_pyfunction!(decompress_profile, m)?)?;
     Ok(())
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,6 +1,11 @@
-use pyo3::pyclass;
+use pyo3::{pyclass, PyErr, PyResult};
 
-use crate::{android::profile::AndroidProfile, sample::v1::SampleProfile, types::ProfileInterface};
+use crate::{
+    android::profile::AndroidProfile,
+    sample::v1::SampleProfile,
+    types::ProfileInterface,
+    utils::{compress_lz4, decompress_lz4},
+};
 
 #[pyclass]
 pub struct Profile {
@@ -51,6 +56,21 @@ impl Profile {
         }
     }
 
+    pub(crate) fn decompress(source: &[u8]) -> Result<Self, Box<dyn std::error::Error>> {
+        let bytes = decompress_lz4(source)?;
+        Self::from_json_vec(bytes.as_ref())
+            .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
+    }
+
+    pub fn compress(&self) -> PyResult<Vec<u8>> {
+        let prof = self
+            .profile
+            .to_json_vec()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+        compress_lz4(&mut prof.as_slice())
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+    }
+
     pub fn get_platform(&self) -> String {
         self.profile.get_platform().to_string()
     }
@@ -58,7 +78,10 @@ impl Profile {
 
 #[cfg(test)]
 mod tests {
-    use crate::{profile::Profile, types::Platform};
+    use crate::{
+        android::profile::AndroidProfile, profile::Profile, sample::v1::SampleProfile,
+        types::Platform,
+    };
 
     #[test]
     fn test_from_json_vec() {
@@ -137,6 +160,65 @@ mod tests {
                 "test `{}` failed",
                 test.name
             )
+        }
+    }
+
+    #[test]
+    fn test_compress_decompress() {
+        struct TestStruct {
+            name: String,
+            payload: &'static [u8],
+        }
+
+        let test_cases = [
+            TestStruct {
+                name: "compressing and decompressing cocoa (V1)".to_string(),
+                payload: include_bytes!("../tests/fixtures/sample/v1/valid_cocoa.json"),
+            },
+            TestStruct {
+                name: "compressing and decompressing python (V1)".to_string(),
+                payload: include_bytes!("../tests/fixtures/sample/v1/valid_python.json"),
+            },
+            TestStruct {
+                name: "compressing and decompressing android profile".to_string(),
+                payload: include_bytes!("../tests/fixtures/android/profile/valid.json"),
+            },
+        ];
+
+        for test in test_cases {
+            let profile = Profile::from_json_vec(test.payload).unwrap();
+
+            let compressed_profile_bytes = profile.compress().unwrap();
+            let decompressed_profile =
+                Profile::decompress(compressed_profile_bytes.as_slice()).unwrap();
+
+            let equals = if profile.get_platform() == Platform::Android.to_string() {
+                let original_sample = profile
+                    .profile
+                    .as_any()
+                    .downcast_ref::<AndroidProfile>()
+                    .unwrap();
+                let final_sample = decompressed_profile
+                    .profile
+                    .as_any()
+                    .downcast_ref::<AndroidProfile>()
+                    .unwrap();
+                original_sample == final_sample
+            } else {
+                let original_sample = profile
+                    .profile
+                    .as_any()
+                    .downcast_ref::<SampleProfile>()
+                    .unwrap();
+                let final_sample = decompressed_profile
+                    .profile
+                    .as_any()
+                    .downcast_ref::<SampleProfile>()
+                    .unwrap();
+                original_sample == final_sample
+            };
+
+            assert!(equals, "test `{}` failed", test.name);
         }
     }
 }

--- a/src/sample/v1.rs
+++ b/src/sample/v1.rs
@@ -127,6 +127,15 @@ impl ProfileInterface for SampleProfile {
     fn get_platform(&self) -> Platform {
         self.platform
     }
+
+    /// Serialize the given data structure as a JSON byte vector.
+    fn to_json_vec(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(&self)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -213,5 +213,10 @@ pub struct TransactionMetadata {
     segment_id: Option<String>,
 }
 pub trait ProfileInterface {
+    /// Serialize the given data structure as a JSON byte vector.
+    fn to_json_vec(&self) -> Result<Vec<u8>, serde_json::Error>;
+
     fn get_platform(&self) -> Platform;
+
+    fn as_any(&self) -> &dyn Any;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,24 @@
+use std::io;
+
+use lz4::{Decoder, EncoderBuilder};
+
+pub(crate) fn decompress_lz4(source: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    let mut decoder = Decoder::new(source)?;
+    let mut decoded_data: Vec<u8> = vec![];
+    io::copy(&mut decoder, &mut decoded_data)?;
+    Ok(decoded_data)
+}
+
+pub(crate) fn compress_lz4(source: &mut &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    let b: Vec<u8> = vec![];
+    let mut encoder = EncoderBuilder::new()
+        .block_checksum(lz4::liblz4::BlockChecksum::NoBlockChecksum)
+        .level(9)
+        .build(b)?;
+    io::copy(source, &mut encoder)?;
+    let (compressed_data, res) = encoder.finish();
+    match res {
+        Ok(_) => Ok(compressed_data),
+        Err(error) => Err(error),
+    }
+}


### PR DESCRIPTION
This adds the utilities to compress a transaction profile to lz4 and decompress from the same.