### PR TITLE
feat: add missing method to expose to python and relative sphinx docs

### DIFF
--- a/src/android/profile.rs
+++ b/src/android/profile.rs
@@ -218,6 +218,25 @@ impl ProfileInterface for AndroidProfile {
         } // end if js_profile
         self.profile.call_trees()
     }
+
+    fn storage_path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.organization_id, self.project_id, self.profile_id
+        )
+    }
+
+    fn sdk_name(&self) -> Option<&str> {
+        self.client_sdk.as_deref().map(|sdk| sdk.name.as_str())
+    }
+
+    fn sdk_version(&self) -> Option<&str> {
+        self.client_sdk.as_deref().map(|sdk| sdk.version.as_str())
+    }
+
+    fn duration_ns(&self) -> u64 {
+        self.duration_ns
+    }
 }
 
 // CallTree generation expect activeThreadID to be set in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,29 @@ fn profile_chunk_from_json_str(profile: &str, platform: Option<&str>) -> PyResul
     }
 }
 
+/// Returns a `Profile` instance from a json string
+///
+/// Arguments
+/// ---------
+/// profile : str
+///   A profile serialized as json string
+///
+///     platform (string): An optional string representing the profile platform.
+///         If provided, we can directly deserialize to the right profile more
+///         efficiently.
+///         If the platform is known at the time this function is invoked, it's
+///         recommended to always pass it.
+///
+/// Returns
+/// -------
+/// :class:`vroomrs.Profile`
+///   A `Profile` instance
+///
+/// Raises
+/// -------
+/// pyo3.exceptions.PyException
+///     If an error occurs during the extraction process.
+///
 #[pyfunction]
 #[pyo3(signature = (profile, platform=None))]
 fn profile_from_json_str(profile: &str, platform: Option<&str>) -> PyResult<Profile> {
@@ -89,6 +112,29 @@ fn decompress_profile_chunk(profile: &[u8]) -> PyResult<ProfileChunk> {
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
 }
 
+/// Returns a `Profile` instance from a lz4 encoded profile.
+///
+/// Arguments
+/// ---------
+/// profile : bytes
+///   A lz4 encoded profile.
+///
+/// Returns
+/// -------
+/// :class:`vroomrs.Profile`
+///   A `Profile` instance
+///
+/// Raises
+/// ------
+/// pyo3.exceptions.PyException
+///     If an error occurs during the extraction process.
+///
+/// Example
+/// --------
+///     >>> with open("profile_compressed.lz4", "rb") as binary_file:
+///     ...     profile = vroomrs.decompress_profile(binary_file.read())
+///             # do something with the profile
+///
 #[pyfunction]
 fn decompress_profile(profile: &[u8]) -> PyResult<Profile> {
     Profile::decompress(profile)

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -64,7 +64,163 @@ impl Profile {
         Self::from_json_vec(bytes.as_ref())
             .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
     }
+}
 
+#[pymethods]
+impl Profile {
+    /// Applies the various normalization steps,
+    /// depending on the profile's platform.
+    pub fn normalize(&mut self) {
+        self.profile.normalize();
+    }
+
+    /// Returns the environment.
+    ///
+    /// Returns:
+    ///     str
+    ///         The environment, or None, if release is not available.
+    pub fn get_environment(&self) -> Option<&str> {
+        self.profile.get_environment()
+    }
+
+    /// Returns the organization ID.
+    ///
+    /// Returns:
+    ///     int
+    ///         The organization ID to which the profile belongs.
+    pub fn get_organization_id(&self) -> u64 {
+        self.profile.get_organization_id()
+    }
+
+    /// Returns the profile platform.
+    ///
+    /// Returns:
+    ///     str
+    ///         The profile's platform. One of the following values:
+    ///             * android
+    ///             * cocoa
+    ///             * java
+    ///             * javascript
+    ///             * php
+    ///             * node
+    ///             * python
+    ///             * rust
+    ///             * none
+    pub fn get_platform(&self) -> String {
+        self.profile.get_platform().to_string()
+    }
+
+    /// Returns the profil ID.
+    ///
+    /// Returns:
+    ///     str
+    ///         The profile ID of the profile.
+    pub fn get_profiler_id(&self) -> &str {
+        self.profile.get_profile_id()
+    }
+
+    /// Returns the project ID.
+    ///
+    /// Returns:
+    ///     int
+    ///         The project ID to which the profile belongs.
+    pub fn get_project_id(&self) -> u64 {
+        self.profile.get_project_id()
+    }
+
+    /// Returns the received timestamp.
+    ///
+    /// Returns:
+    ///     float
+    fn get_received(&self) -> f64 {
+        self.profile.get_received()
+    }
+
+    /// Returns the release.
+    ///
+    /// Returns:
+    ///     str
+    ///         The release of the SDK used to collect this profile,
+    ///         or None, if release is not available.
+    pub fn get_release(&self) -> Option<&str> {
+        self.profile.get_release()
+    }
+
+    /// Returns the retention days.
+    ///
+    /// Returns:
+    ///     int
+    ///         The retention days.
+    pub fn get_retention_days(&self) -> i32 {
+        self.profile.get_retention_days()
+    }
+
+    /// Returns the duration of the profile in ns.
+    ///
+    /// Returns:
+    ///     int
+    ///         The duration of the profile in ns.
+    pub fn duration_ns(&self) -> u64 {
+        self.profile.duration_ns()
+    }
+
+    /// Returns the end timestamp of the profile.
+    ///
+    /// The timestamp is a Unix timestamp in seconds
+    /// with millisecond precision.
+    ///
+    /// Returns:
+    ///     float
+    ///         The timestamp of the profile.
+    pub fn get_timestamp(&self) -> f64 {
+        self.profile.get_timestamp()
+    }
+
+    /// Returns the SDK name.
+    ///
+    /// Returns:
+    ///     str
+    ///         The name of the SDK used to collect this profile,
+    ///         or None, if version is not available.
+    pub fn sdk_name(&self) -> Option<&str> {
+        self.profile.sdk_name()
+    }
+
+    /// Returns the SDK version.
+    ///
+    /// Returns:
+    ///     str
+    ///         The version of the SDK used to collect this profile,
+    ///         or None, if version is not available.
+    pub fn sdk_version(&self) -> Option<&str> {
+        self.profile.sdk_version()
+    }
+
+    /// Returns the storage path of the profile.
+    ///
+    /// Returns:
+    ///     str
+    ///         The storage path of the profile.
+    pub fn storage_path(&self) -> String {
+        self.profile.storage_path()
+    }
+
+    /// Compresses the profile with lz4.
+    ///
+    /// This method serializes the profile to json and then compresses it with lz4,
+    /// returning the bytes representing the lz4 encoded profile.
+    ///
+    /// Returns:
+    ///     bytes
+    ///         A bytes object representing the lz4 encoded profile.
+    ///
+    /// Raises:
+    ///     pyo3.exceptions.PyException: If an error occurs during the extraction process.
+    ///
+    /// Example:
+    ///     >>> compressed_profile = profile.compress()
+    ///     >>> with open("profile_compressed.lz4", "wb+") as binary_file:
+    ///     ...     binary_file.write(compressed_profile)
     pub fn compress(&self) -> PyResult<Vec<u8>> {
         let prof = self
             .profile
@@ -74,13 +230,31 @@ impl Profile {
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
     }
 
-    pub fn get_platform(&self) -> String {
-        self.profile.get_platform().to_string()
-    }
-}
-
-#[pymethods]
-impl Profile {
+    /// Extracts function metrics from the call tree.
+    ///
+    /// This method analyzes the call tree and extracts metrics for each function,
+    /// returning a list of `CallTreeFunction` objects.
+    ///
+    /// Args:
+    ///     min_depth (int): The minimum depth of the node in the call tree.
+    ///         When computing slowest functions, ignore frames/node whose depth in the callTree
+    ///         is less than min_depth (i.e. if min_depth=1, we'll ignore root frames).
+    ///     filter_system_frames (bool): If `True`, system frames (e.g., standard library calls) will be filtered out.
+    ///     max_unique_functions (int): An optional maximum number of unique functions to extract.
+    ///         If provided, only the top `max_unique_functions` slowest functions will be returned.
+    ///         If `None`, all functions will be returned.
+    ///
+    /// Returns:
+    ///     list[:class:`CallTreeFunction`]
+    ///         A list of :class:`CallTreeFunction` objects, each containing metrics for a function in the call tree.
+    ///
+    /// Raises:
+    ///     pyo3.exceptions.PyException: If an error occurs during the extraction process.
+    ///
+    /// Example:
+    ///     >>> metrics = call_tree.extract_functions_metrics(min_depth=2, filter_system_frames=True, max_unique_functions=10)
+    ///     >>> for function_metric in metrics:
+    ///     ...     do_something(function_metric)
     #[pyo3(signature = (min_depth, filter_system_frames, max_unique_functions=None))]
     pub fn extract_functions_metrics(
         &mut self,

--- a/src/sample/v1.rs
+++ b/src/sample/v1.rs
@@ -399,6 +399,13 @@ impl ProfileInterface for SampleProfile {
         self.profile.replace_idle_stacks();
     }
 
+    fn storage_path(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.organization_id, self.project_id, self.event_id
+        )
+    }
+
     fn call_trees(&mut self) -> Result<CallTreesU64, CallTreeError> {
         // Sort samples by timestamp
         self.profile
@@ -506,6 +513,22 @@ impl ProfileInterface for SampleProfile {
             }
         }
         Ok(trees_by_thread_id)
+    }
+
+    fn sdk_name(&self) -> Option<&str> {
+        self.client_sdk.as_deref().map(|sdk| sdk.name.as_str())
+    }
+
+    fn sdk_version(&self) -> Option<&str> {
+        self.client_sdk.as_deref().map(|sdk| sdk.version.as_str())
+    }
+
+    fn duration_ns(&self) -> u64 {
+        if self.profile.samples.is_empty() {
+            return 0;
+        }
+        self.profile.samples.last().unwrap().elapsed_since_start_ns
+            - self.profile.samples.first().unwrap().elapsed_since_start_ns
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -227,6 +227,10 @@ pub trait ProfileInterface {
     fn get_timestamp(&self) -> f64;
     fn normalize(&mut self);
     fn call_trees(&mut self) -> Result<CallTreesU64, CallTreeError>;
+    fn storage_path(&self) -> String;
+    fn sdk_name(&self) -> Option<&str>;
+    fn sdk_version(&self) -> Option<&str>;
+    fn duration_ns(&self) -> u64;
 
     /// Serialize the given data structure as a JSON byte vector.
     fn to_json_vec(&self) -> Result<Vec<u8>, serde_json::Error>;


### PR DESCRIPTION
This adds the missing methods to be exposed to Python for the transaction-based profiling and the sphinx docs for both these new ones and the existing ones.