### PR TITLE
feat: make thread_metadata optional

### DIFF
--- a/src/sample/v2.rs
+++ b/src/sample/v2.rs
@@ -53,7 +53,8 @@ pub struct SampleData {
     pub frames: Vec<Frame>,
     pub samples: Vec<Sample>,
     pub stacks: Vec<Vec<i32>>,
-    pub thread_metadata: std::collections::HashMap<String, ThreadMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_metadata: Option<std::collections::HashMap<String, ThreadMetadata>>,
 }
 
 impl SampleData {


### PR DESCRIPTION
This is to align with the Relay definition: https://github.com/getsentry/relay/blob/master/relay-profiling/src/sample/v2.rs#L90-L94