### PR TITLE
fix: change received field to integer

### DIFF
--- a/src/android/profile.rs
+++ b/src/android/profile.rs
@@ -68,7 +68,7 @@ pub struct AndroidProfile {
 
     project_id: u64,
 
-    received: f64,
+    received: i64,
 
     release: Option<String>,
 
@@ -134,7 +134,7 @@ impl ProfileInterface for AndroidProfile {
         self.project_id
     }
 
-    fn get_received(&self) -> f64 {
+    fn get_received(&self) -> i64 {
         self.received
     }
 

--- a/src/occurrence/mod.rs
+++ b/src/occurrence/mod.rs
@@ -784,7 +784,7 @@ pub fn new_occurrence(profile: &dyn ProfileInterface, mut ni: NodeInfo) -> Occur
         event_id: event_id(),
         platform: platform.to_string(),
         project_id: profile.get_project_id(),
-        received: DateTime::from_timestamp_micros((profile.get_received() * 1e6) as i64)
+        received: DateTime::from_timestamp(profile.get_received(), 0)
             .expect("timestamp out of range"),
         release: profile.get_release().map(|s| s.to_string()),
         stacktrace: StackTrace {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -173,8 +173,8 @@ impl Profile {
     /// Returns the received timestamp.
     ///
     /// Returns:
-    ///     float
-    fn get_received(&self) -> f64 {
+    ///     int
+    fn get_received(&self) -> i64 {
         self.profile.get_received()
     }
 

--- a/src/sample/v1.rs
+++ b/src/sample/v1.rs
@@ -109,7 +109,7 @@ pub struct SampleProfile {
 
     pub project_id: u64,
 
-    pub received: f64,
+    pub received: i64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub release: Option<String>,
@@ -372,7 +372,7 @@ impl ProfileInterface for SampleProfile {
         self.project_id
     }
 
-    fn get_received(&self) -> f64 {
+    fn get_received(&self) -> i64 {
         self.received
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -274,7 +274,7 @@ pub trait ProfileInterface {
     fn get_organization_id(&self) -> u64;
     fn get_platform(&self) -> Platform;
     fn get_project_id(&self) -> u64;
-    fn get_received(&self) -> f64;
+    fn get_received(&self) -> i64;
     fn get_release(&self) -> Option<&str>;
     fn get_retention_days(&self) -> i32;
     fn get_timestamp(&self) -> DateTime<Utc>;

--- a/vroomrs.pyi
+++ b/vroomrs.pyi
@@ -56,12 +56,12 @@ class Profile:
         """
         ...
     
-    def get_received(self) -> float:
+    def get_received(self) -> int:
         """
         Returns the received timestamp.
 
         Returns:
-            float: The received timestamp.
+            int: The received timestamp.
         """
         ...
     


### PR DESCRIPTION
In sample format v1 and legacy android profiles, `received` is either expected to be either a Time "parsable" (rfc 3339 formatted string) or an int.

Therefore we're changing the type to int in the V1 implementation to make it compatible with what vroom expect.