### PR TITLE
ref: replace platform type with string

### DIFF
--- a/src/android/chunk.rs
+++ b/src/android/chunk.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     nodetree::Node,
-    types::{CallTreeError, CallTreesStr, ChunkInterface, ClientSDK, DebugMeta, Platform},
+    types::{CallTreeError, CallTreesStr, ChunkInterface, ClientSDK, DebugMeta},
 };
 
 use super::Android;
@@ -22,7 +22,7 @@ pub struct AndroidChunk {
     duration_ns: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     environment: Option<String>,
-    platform: Platform,
+    platform: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     release: Option<String>,
     timestamp: f64,
@@ -67,8 +67,8 @@ impl ChunkInterface for AndroidChunk {
         self.organization_id
     }
 
-    fn get_platform(&self) -> Platform {
-        self.platform
+    fn get_platform(&self) -> String {
+        self.platform.clone()
     }
 
     fn get_profiler_id(&self) -> &str {

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::frame::{self, Frame};
 use crate::nodetree;
 use crate::types::{CallTreeError, CallTreesU64};
-use crate::{nodetree::Node, types::Platform, MAX_STACK_DEPTH};
+use crate::{nodetree::Node, MAX_STACK_DEPTH};
 
 const MAIN_THREAD: &str = "main";
 const ANDROID_PACKAGE_PREFIXES: [&str; 11] = [
@@ -68,7 +68,7 @@ struct AndroidMethod {
     #[serde(skip_serializing_if = "Option::is_none")]
     in_app: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    platform: Option<Platform>,
+    platform: Option<String>,
 }
 
 impl AndroidMethod {
@@ -140,7 +140,7 @@ impl AndroidMethod {
             } else {
                 Some(self.source_file.to_owned())
             },
-            platform: self.platform,
+            platform: self.platform.clone(),
             ..Default::default()
         }
     }

--- a/src/android/profile.rs
+++ b/src/android/profile.rs
@@ -7,8 +7,7 @@ use crate::{
     android::AndroidError,
     sample::v1::{Measurement, Profile, RuntimeMetadata, SampleProfile},
     types::{
-        CallTreeError, ClientSDK, DebugMeta, Platform, ProfileInterface, Transaction,
-        TransactionMetadata,
+        CallTreeError, ClientSDK, DebugMeta, ProfileInterface, Transaction, TransactionMetadata,
     },
 };
 
@@ -60,7 +59,7 @@ pub struct AndroidProfile {
 
     organization_id: u64,
 
-    platform: Platform,
+    platform: String,
 
     profile: Android,
 
@@ -105,8 +104,8 @@ pub struct NestedProfile {
 }
 
 impl ProfileInterface for AndroidProfile {
-    fn get_platform(&self) -> Platform {
-        self.platform
+    fn get_platform(&self) -> String {
+        self.platform.clone()
     }
 
     /// Serialize the given data structure as a JSON byte vector.
@@ -155,7 +154,7 @@ impl ProfileInterface for AndroidProfile {
             let mut js_profile: NestedProfile = serde_json::from_value(js_profile_json.clone())
                 .expect("error while deserializing js_profile");
             let mut sample_profile = SampleProfile {
-                platform: Platform::JavaScript,
+                platform: "javascript".to_string(),
                 profile: js_profile.profile,
                 ..Default::default()
             };
@@ -195,7 +194,7 @@ impl ProfileInterface for AndroidProfile {
             let js_profile: NestedProfile = serde_json::from_value(js_profile_json.clone())
                 .expect("error while deserializing js_profile");
             let mut sample_profile = SampleProfile {
-                platform: Platform::JavaScript,
+                platform: "javascript".to_string(),
                 profile: js_profile.profile,
                 ..Default::default()
             };

--- a/src/occurrence/detect_frame.rs
+++ b/src/occurrence/detect_frame.rs
@@ -4,7 +4,7 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc, time::Duration};
 use crate::{
     frame::Frame,
     nodetree::Node,
-    types::{CallTreesU64, Platform, ProfileInterface},
+    types::{CallTreesU64, ProfileInterface},
     MAX_STACK_DEPTH,
 };
 
@@ -183,11 +183,11 @@ impl DetectFrameOptions for DetectAndroidFrameOptions {
 
 /// Platform-specific frame detection job configurations.
 pub static DETECT_FRAME_JOBS: Lazy<
-    HashMap<Platform, Vec<Box<dyn DetectFrameOptions + Send + Sync>>>,
+    HashMap<String, Vec<Box<dyn DetectFrameOptions + Send + Sync>>>,
 > = Lazy::new(|| {
     HashMap::from([
         // Node.js platform
-        (Platform::Node, vec![
+        ("node".to_string(), vec![
             Box::new(DetectExactFrameOptions {
                 active_thread_only: true,
                 duration_threshold: Duration::from_millis(0),
@@ -252,7 +252,7 @@ pub static DETECT_FRAME_JOBS: Lazy<
             }) as Box<dyn DetectFrameOptions + Send + Sync>,
         ]),
         // Cocoa platform
-        (Platform::Cocoa, vec![
+        ("cocoa".to_string(), vec![
             Box::new(DetectExactFrameOptions {
                 active_thread_only: true,
                 duration_threshold: Duration::from_millis(16),
@@ -396,7 +396,7 @@ pub static DETECT_FRAME_JOBS: Lazy<
             }) as Box<dyn DetectFrameOptions + Send + Sync>,
         ]),
         // Android platform
-        (Platform::Android, vec![
+        ("android".to_string(), vec![
             Box::new(DetectAndroidFrameOptions {
                 active_thread_only: true,
                 duration_threshold: Duration::from_millis(40),

--- a/src/occurrence/frame_drop.rs
+++ b/src/occurrence/frame_drop.rs
@@ -280,7 +280,7 @@ mod tests {
         use crate::sample::v1::{
             Measurement, MeasurementValue, Profile as SampleProfileData, SampleProfile,
         };
-        use crate::types::{Platform, ProfileInterface, Transaction};
+        use crate::types::{ProfileInterface, Transaction};
 
         struct TestCase {
             name: String,
@@ -310,7 +310,7 @@ mod tests {
                         name: "some".to_string(),
                         ..Default::default()
                     },
-                    platform: Platform::Cocoa,
+                    platform: "cocoa".to_string(),
                     profile: SampleProfileData {
                         frames: vec![],
                         samples: vec![
@@ -483,7 +483,7 @@ mod tests {
                         name: "some".to_string(),
                         ..Default::default()
                     },
-                    platform: Platform::Cocoa,
+                    platform: "cocoa".to_string(),
                     profile: SampleProfileData {
                         frames: vec![],
                         samples: vec![
@@ -723,7 +723,7 @@ mod tests {
                         name: "some".to_string(),
                         ..Default::default()
                     },
-                    platform: Platform::Cocoa,
+                    platform: "cocoa".to_string(),
                     profile: SampleProfileData {
                         frames: vec![],
                         samples: vec![
@@ -953,7 +953,7 @@ mod tests {
                         name: "some".to_string(),
                         ..Default::default()
                     },
-                    platform: Platform::Cocoa,
+                    platform: "cocoa".to_string(),
                     profile: SampleProfileData {
                         frames: vec![],
                         samples: vec![

--- a/src/occurrence/mod.rs
+++ b/src/occurrence/mod.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::{
     android, frame,
-    types::{CallTreesU64, DebugMeta, Platform, ProfileInterface},
+    types::{CallTreesU64, DebugMeta, ProfileInterface},
 };
 
 mod detect_frame;
@@ -655,7 +655,7 @@ pub fn generate_evidence_data(
     match node_info.category.as_str() {
         FRAME_DROP => {}
         _ => {
-            if profile.get_platform() == Platform::Android {
+            if profile.get_platform().as_str() == "android" {
                 evidence_data.sample_count = Some(node_info.node.sample_count);
             }
         }
@@ -724,8 +724,8 @@ pub fn generate_evidence_display(
                 Duration::from_micros(10),
             );
 
-            let duration_str = match profile.get_platform() {
-                Platform::Android => {
+            let duration_str = match profile.get_platform().as_str() {
+                "android" => {
                     format!("{duration:?} ({profile_percentage:.2}% of the profile)")
                 }
                 _ => {
@@ -778,8 +778,8 @@ pub fn new_occurrence(profile: &dyn ProfileInterface, mut ni: NodeInfo) -> Occur
     let mut platform = profile.get_platform();
 
     // Handle Android platform special case
-    if platform == Platform::Android {
-        platform = Platform::Java;
+    if platform.as_str() == "android" {
+        platform = "java".to_string();
         normalize_android_stack_trace(&mut ni.stack_trace);
         ni.node.name =
             android::strip_package_name_from_full_method_name(&ni.node.name, &ni.node.package);

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -138,16 +138,7 @@ impl Profile {
     ///
     /// Returns:
     ///     str
-    ///         The profile's platform. One of the following values:
-    ///             * android
-    ///             * cocoa
-    ///             * java
-    ///             * javascript
-    ///             * php
-    ///             * node
-    ///             * python
-    ///             * rust
-    ///             * none
+    ///         The profile's platform.
     pub fn get_platform(&self) -> String {
         self.profile.get_platform().to_string()
     }
@@ -407,10 +398,7 @@ impl Profile {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        android::profile::AndroidProfile, profile::Profile, sample::v1::SampleProfile,
-        types::Platform,
-    };
+    use crate::{android::profile::AndroidProfile, profile::Profile, sample::v1::SampleProfile};
 
     #[test]
     fn test_from_json_vec() {
@@ -424,17 +412,17 @@ mod tests {
             TestStruct {
                 name: "cocoa profile".to_string(),
                 profile_json: include_bytes!("../tests/fixtures/sample/v1/valid_cocoa.json"),
-                want: Platform::Cocoa.to_string(),
+                want: "cocoa".to_string(),
             },
             TestStruct {
                 name: "python profile".to_string(),
                 profile_json: include_bytes!("../tests/fixtures/sample/v1/valid_python.json"),
-                want: Platform::Python.to_string(),
+                want: "python".to_string(),
             },
             TestStruct {
                 name: "android profile".to_string(),
                 profile_json: include_bytes!("../tests/fixtures/android/profile/valid.json"),
-                want: Platform::Android.to_string(),
+                want: "android".to_string(),
             },
         ];
 
@@ -464,19 +452,19 @@ mod tests {
                 name: "cocoa profile".to_string(),
                 platform: "cocoa",
                 profile_json: include_bytes!("../tests/fixtures/sample/v1/valid_cocoa.json"),
-                want: Platform::Cocoa.to_string(),
+                want: "cocoa".to_string(),
             },
             TestStruct {
                 name: "python profile".to_string(),
                 platform: "python",
                 profile_json: include_bytes!("../tests/fixtures/sample/v1/valid_python.json"),
-                want: Platform::Python.to_string(),
+                want: "python".to_string(),
             },
             TestStruct {
                 name: "android profile".to_string(),
                 platform: "android",
                 profile_json: include_bytes!("../tests/fixtures/android/profile/valid.json"),
-                want: Platform::Android.to_string(),
+                want: "android".to_string(),
             },
         ];
 
@@ -521,7 +509,7 @@ mod tests {
             let decompressed_profile =
                 Profile::decompress(compressed_profile_bytes.as_slice()).unwrap();
 
-            let equals = if profile.get_platform() == Platform::Android.to_string() {
+            let equals = if profile.get_platform().as_str() == "android" {
                 let original_sample = profile
                     .profile
                     .as_any()

--- a/src/profile_chunk.rs
+++ b/src/profile_chunk.rs
@@ -106,16 +106,7 @@ impl ProfileChunk {
     ///
     /// Returns:
     ///     str
-    ///         The profile's platform. One of the following values:
-    ///             * android
-    ///             * cocoa
-    ///             * java
-    ///             * javascript
-    ///             * php
-    ///             * node
-    ///             * python
-    ///             * rust
-    ///             * none
+    ///         The profile's platform.
     pub fn get_platform(&self) -> String {
         self.profile.get_platform().to_string()
     }
@@ -319,7 +310,6 @@ impl ProfileChunk {
 mod tests {
     use crate::{
         android::chunk::AndroidChunk, profile_chunk::ProfileChunk, sample::v2::SampleChunk,
-        types::Platform,
     };
 
     #[test]
@@ -334,17 +324,17 @@ mod tests {
             TestStruct {
                 name: "cocoa profile".to_string(),
                 profile_json: include_bytes!("../tests/fixtures/sample/v2/valid_cocoa.json"),
-                want: Platform::Cocoa.to_string(),
+                want: "cocoa".to_string(),
             },
             TestStruct {
                 name: "python profile".to_string(),
                 profile_json: include_bytes!("../tests/fixtures/sample/v2/valid_python.json"),
-                want: Platform::Python.to_string(),
+                want: "python".to_string(),
             },
             TestStruct {
                 name: "android profile".to_string(),
                 profile_json: include_bytes!("../tests/fixtures/android/chunk/valid.json"),
-                want: Platform::Android.to_string(),
+                want: "android".to_string(),
             },
         ];
 
@@ -374,19 +364,19 @@ mod tests {
                 name: "cocoa profile".to_string(),
                 platform: "cocoa",
                 profile_json: include_bytes!("../tests/fixtures/sample/v2/valid_cocoa.json"),
-                want: Platform::Cocoa.to_string(),
+                want: "cocoa".to_string(),
             },
             TestStruct {
                 name: "python profile".to_string(),
                 platform: "python",
                 profile_json: include_bytes!("../tests/fixtures/sample/v2/valid_python.json"),
-                want: Platform::Python.to_string(),
+                want: "python".to_string(),
             },
             TestStruct {
                 name: "android profile".to_string(),
                 platform: "android",
                 profile_json: include_bytes!("../tests/fixtures/android/chunk/valid.json"),
-                want: Platform::Android.to_string(),
+                want: "android".to_string(),
             },
         ];
 
@@ -431,7 +421,7 @@ mod tests {
             let decompressed_profile =
                 ProfileChunk::decompress(compressed_profile_bytes.as_slice()).unwrap();
 
-            let equals = if profile.get_platform() == Platform::Android.to_string() {
+            let equals = if profile.get_platform().as_str() == "android" {
                 let original_sample = profile
                     .profile
                     .as_any()

--- a/src/sample/v1.rs
+++ b/src/sample/v1.rs
@@ -3,7 +3,7 @@ use crate::{
     nodetree::Node,
     sample::SampleError,
     types::{
-        CallTreeError, CallTreesU64, ClientSDK, DebugMeta, Platform, ProfileInterface, Transaction,
+        CallTreeError, CallTreesU64, ClientSDK, DebugMeta, ProfileInterface, Transaction,
         TransactionMetadata,
     },
 };
@@ -105,7 +105,7 @@ pub struct SampleProfile {
 
     pub organization_id: u64,
 
-    pub platform: Platform,
+    pub platform: String,
 
     pub project_id: u64,
 
@@ -343,8 +343,8 @@ fn find_common_frames<'a>(
 }
 
 impl ProfileInterface for SampleProfile {
-    fn get_platform(&self) -> Platform {
-        self.platform
+    fn get_platform(&self) -> String {
+        self.platform.clone()
     }
 
     /// Serialize the given data structure as a JSON byte vector.
@@ -390,11 +390,11 @@ impl ProfileInterface for SampleProfile {
 
     fn normalize(&mut self) {
         for frame in &mut self.profile.frames {
-            frame.normalize(self.platform);
+            frame.normalize(&self.platform);
         }
-        if self.platform == Platform::Cocoa {
+        if self.platform.as_str() == "cocoa" {
             self.trim_cocoa_stacks();
-        } else if self.platform == Platform::Python {
+        } else if self.platform.as_str() == "python" {
             self.profile.trim_python_stacks();
         }
 
@@ -592,7 +592,7 @@ mod tests {
     use crate::{
         frame::{self, Data, Frame},
         sample::v1::{Profile, Sample, SampleProfile},
-        types::{CallTreesU64, Platform, ProfileInterface, Transaction},
+        types::{CallTreesU64, ProfileInterface, Transaction},
     };
 
     #[test]
@@ -632,7 +632,7 @@ mod tests {
                                 }),
                                 function: Some("function1".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -642,7 +642,7 @@ mod tests {
                                 }),
                                 function: Some("function2".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -652,7 +652,7 @@ mod tests {
                                 }),
                                 function: Some("main".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -660,7 +660,7 @@ mod tests {
                                     symbolicator_status: Some("missing".to_string()),
                                     ..Default::default()
                                 }),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                         ], // end frames definition
@@ -679,7 +679,7 @@ mod tests {
                                 }),
                                 function: Some("function1".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -689,7 +689,7 @@ mod tests {
                                 }),
                                 function: Some("function2".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -699,7 +699,7 @@ mod tests {
                                 }),
                                 function: Some("main".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -707,7 +707,7 @@ mod tests {
                                     symbolicator_status: Some("missing".to_string()),
                                     ..Default::default()
                                 }),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                         ], // end frames definition
@@ -729,7 +729,7 @@ mod tests {
                                 }),
                                 function: Some("function1".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -739,7 +739,7 @@ mod tests {
                                 }),
                                 function: Some("function2".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -749,7 +749,7 @@ mod tests {
                                 }),
                                 function: Some("main".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -757,7 +757,7 @@ mod tests {
                                     symbolicator_status: Some("missing".to_string()),
                                     ..Default::default()
                                 }),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -767,7 +767,7 @@ mod tests {
                                 }),
                                 function: Some("start_sim".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                         ], // end frames definition
@@ -786,7 +786,7 @@ mod tests {
                                 }),
                                 function: Some("function1".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -796,7 +796,7 @@ mod tests {
                                 }),
                                 function: Some("function2".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -806,7 +806,7 @@ mod tests {
                                 }),
                                 function: Some("main".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -814,7 +814,7 @@ mod tests {
                                     symbolicator_status: Some("missing".to_string()),
                                     ..Default::default()
                                 }),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -824,7 +824,7 @@ mod tests {
                                 }),
                                 function: Some("start_sim".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                         ], // end frames definition
@@ -846,7 +846,7 @@ mod tests {
                                 }),
                                 function: Some("function1".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -856,7 +856,7 @@ mod tests {
                                 }),
                                 function: Some("function2".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -866,7 +866,7 @@ mod tests {
                                 }),
                                 function: Some("unsymbolicated_main".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -874,7 +874,7 @@ mod tests {
                                     symbolicator_status: Some("missing".to_string()),
                                     ..Default::default()
                                 }),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -884,7 +884,7 @@ mod tests {
                                 }),
                                 function: Some("start_sim".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                         ], // end frames definition
@@ -903,7 +903,7 @@ mod tests {
                                 }),
                                 function: Some("function1".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -913,7 +913,7 @@ mod tests {
                                 }),
                                 function: Some("function2".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -923,7 +923,7 @@ mod tests {
                                 }),
                                 function: Some("unsymbolicated_main".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -931,7 +931,7 @@ mod tests {
                                     symbolicator_status: Some("missing".to_string()),
                                     ..Default::default()
                                 }),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -941,7 +941,7 @@ mod tests {
                                 }),
                                 function: Some("start_sim".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                         ], // end frames definition
@@ -963,7 +963,7 @@ mod tests {
                                 }),
                                 function: Some("function1".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -973,7 +973,7 @@ mod tests {
                                 }),
                                 function: Some("function2".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -983,7 +983,7 @@ mod tests {
                                 }),
                                 function: Some("main".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -991,7 +991,7 @@ mod tests {
                                     symbolicator_status: Some("missing".to_string()),
                                     ..Default::default()
                                 }),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -1001,7 +1001,7 @@ mod tests {
                                 }),
                                 function: Some("start_sim".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                         ], // end frames definition
@@ -1026,7 +1026,7 @@ mod tests {
                                 }),
                                 function: Some("function1".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -1036,7 +1036,7 @@ mod tests {
                                 }),
                                 function: Some("function2".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -1046,7 +1046,7 @@ mod tests {
                                 }),
                                 function: Some("main".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -1054,7 +1054,7 @@ mod tests {
                                     symbolicator_status: Some("missing".to_string()),
                                     ..Default::default()
                                 }),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                             frame::Frame {
@@ -1064,7 +1064,7 @@ mod tests {
                                 }),
                                 function: Some("start_sim".to_string()),
                                 in_app: Some(true),
-                                platform: Some(Platform::Cocoa),
+                                platform: Some("cocoa".to_string()),
                                 ..Default::default()
                             },
                         ], // end frames definition
@@ -1112,7 +1112,7 @@ mod tests {
                             line: Some(11),
                             function: Some("<module>".to_string()),
                             path: Some("/usr/src/app/<string>".to_string()),
-                            platform: Some(Platform::Python),
+                            platform: Some("python".to_string()),
                             ..Default::default()
                         },
                         Frame {
@@ -1122,7 +1122,7 @@ mod tests {
                             line: Some(98),
                             function: Some("foobar".to_string()),
                             path: Some("/usr/src/app/util.py".to_string()),
-                            platform: Some(Platform::Python),
+                            platform: Some("python".to_string()),
                             ..Default::default()
                         },
                     ],
@@ -1138,7 +1138,7 @@ mod tests {
                             line: Some(11),
                             function: Some("<module>".to_string()),
                             path: Some("/usr/src/app/<string>".to_string()),
-                            platform: Some(Platform::Python),
+                            platform: Some("python".to_string()),
                             ..Default::default()
                         },
                         Frame {
@@ -1148,7 +1148,7 @@ mod tests {
                             line: Some(98),
                             function: Some("foobar".to_string()),
                             path: Some("/usr/src/app/util.py".to_string()),
-                            platform: Some(Platform::Python),
+                            platform: Some("python".to_string()),
                             ..Default::default()
                         },
                     ],

--- a/src/sample/v2.rs
+++ b/src/sample/v2.rs
@@ -11,7 +11,7 @@ use super::{SampleError, ThreadMetadata};
 use crate::frame::Frame;
 use crate::nodetree::Node;
 use crate::types::{CallTreeError, CallTreesStr, ChunkInterface};
-use crate::types::{ClientSDK, DebugMeta, Platform};
+use crate::types::{ClientSDK, DebugMeta};
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
 pub struct SampleChunk {
@@ -26,7 +26,7 @@ pub struct SampleChunk {
 
     pub environment: Option<String>,
 
-    pub platform: Platform,
+    pub platform: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub release: Option<String>,
@@ -212,9 +212,9 @@ impl ChunkInterface for SampleChunk {
 
     fn normalize(&mut self) {
         for frame in &mut self.profile.frames {
-            frame.normalize(self.platform);
+            frame.normalize(&self.platform);
         }
-        if matches!(self.platform, Platform::Python) {
+        if self.platform.as_str() == "python" {
             self.profile.trim_python_stacks();
         }
     }
@@ -231,8 +231,8 @@ impl ChunkInterface for SampleChunk {
         self.organization_id
     }
 
-    fn get_platform(&self) -> Platform {
-        self.platform
+    fn get_platform(&self) -> String {
+        self.platform.clone()
     }
 
     fn get_profiler_id(&self) -> &str {
@@ -310,7 +310,7 @@ mod tests {
     use crate::{
         frame::Frame,
         sample::v2::{Sample, SampleData},
-        types::{CallTreesStr, ChunkInterface, Platform},
+        types::{CallTreesStr, ChunkInterface},
     };
 
     use pretty_assertions::assert_eq;
@@ -603,7 +603,7 @@ mod tests {
             TestStruct {
                 name: "Remove module frame at the end of a stack".to_string(),
                 chunk: SampleChunk {
-                    platform: Platform::Python,
+                    platform: "python".to_string(),
                     profile: SampleData {
                         frames: vec![
                             Frame {
@@ -613,7 +613,7 @@ mod tests {
                                 line: Some(11),
                                 function: Some("<module>".to_string()),
                                 path: Some("/usr/src/app/<string>".to_string()),
-                                platform: Some(Platform::Python),
+                                platform: Some("python".to_string()),
                                 ..Default::default()
                             },
                             Frame {
@@ -623,7 +623,7 @@ mod tests {
                                 line: Some(98),
                                 function: Some("foobar".to_string()),
                                 path: Some("/usr/src/app/util.py".to_string()),
-                                platform: Some(Platform::Python),
+                                platform: Some("python".to_string()),
                                 ..Default::default()
                             },
                         ],
@@ -633,7 +633,7 @@ mod tests {
                     ..Default::default()
                 },
                 want: SampleChunk {
-                    platform: Platform::Python,
+                    platform: "python".to_string(),
                     profile: SampleData {
                         frames: vec![
                             Frame {
@@ -643,7 +643,7 @@ mod tests {
                                 line: Some(11),
                                 function: Some("<module>".to_string()),
                                 path: Some("/usr/src/app/<string>".to_string()),
-                                platform: Some(Platform::Python),
+                                platform: Some("python".to_string()),
                                 ..Default::default()
                             },
                             Frame {
@@ -653,7 +653,7 @@ mod tests {
                                 line: Some(98),
                                 function: Some("foobar".to_string()),
                                 path: Some("/usr/src/app/util.py".to_string()),
-                                platform: Some(Platform::Python),
+                                platform: Some("python".to_string()),
                                 ..Default::default()
                             },
                         ],

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,39 +42,6 @@ pub struct ChunkMeasurementValue {
 
     value: f64,
 }
-
-#[pyclass(eq, eq_int)]
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Default, Hash)]
-#[serde(rename_all = "lowercase")]
-pub enum Platform {
-    Android,
-    Cocoa,
-    Java,
-    JavaScript,
-    Node,
-    Php,
-    Python,
-    Rust,
-    #[default]
-    None,
-}
-
-impl fmt::Display for Platform {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Platform::Android => write!(f, "android"),
-            Platform::Cocoa => write!(f, "cocoa"),
-            Platform::Java => write!(f, "java"),
-            Platform::JavaScript => write!(f, "javascript"),
-            Platform::Node => write!(f, "node"),
-            Platform::Php => write!(f, "php"),
-            Platform::Python => write!(f, "python"),
-            Platform::Rust => write!(f, "rust"),
-            Platform::None => write!(f, "none"),
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct ClientSDK {
     pub name: String,
@@ -140,7 +107,7 @@ pub trait ChunkInterface {
     fn get_environment(&self) -> Option<&str>;
     fn get_chunk_id(&self) -> &str;
     fn get_organization_id(&self) -> u64;
-    fn get_platform(&self) -> Platform;
+    fn get_platform(&self) -> String;
     fn get_profiler_id(&self) -> &str;
     fn get_project_id(&self) -> u64;
     fn get_received(&self) -> f64;
@@ -272,7 +239,7 @@ pub trait ProfileInterface {
     fn get_environment(&self) -> Option<&str>;
     fn get_profile_id(&self) -> &str;
     fn get_organization_id(&self) -> u64;
-    fn get_platform(&self) -> Platform;
+    fn get_platform(&self) -> String;
     fn get_project_id(&self) -> u64;
     fn get_received(&self) -> i64;
     fn get_release(&self) -> Option<&str>;

--- a/vroomrs.pyi
+++ b/vroomrs.pyi
@@ -34,16 +34,7 @@ class Profile:
         Returns the profile platform.
 
         Returns:
-            str: The profile's platform. One of the following values:
-                * android
-                * cocoa
-                * java
-                * javascript
-                * php
-                * node
-                * python
-                * rust
-                * none
+            str: The profile's platform.
         """
         ...
 
@@ -300,16 +291,7 @@ class ProfileChunk:
         Returns the profile platform.
 
         Returns:
-            str: The profile's platform. One of the following values:
-                * android
-                * cocoa
-                * java
-                * javascript
-                * php
-                * node
-                * python
-                * rust
-                * none
+            str: The profile's platform.
         """
         ...
     


### PR DESCRIPTION
This is an improvement that replace the `Platform` type from `enum` to `string` (as it is in `vroom`).

This will let other used easily add support for new platform without us having to release a new `vroomrs` version with the specific platform each time.