### PR TITLE
fix android timestamp

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,17 @@
+import vroomrs
+
+# with open("/Users/vigliasentry/Desktop/tr_prof_950a1ebb1e664a17b4cd88e0728a4173", "rb") as f:
+#     p = vroomrs.decompress_profile(f.read())
+
+with open("/Users/vigliasentry/Downloads/sentry_sentry_1aabc37c83084af8a89efba76b513b2d.profile.json", "r") as f:
+    p = vroomrs.profile_from_json_str(f.read(), "python")
+
+print(p.get_platform())
+print(p.get_project_id())
+print(p.get_organization_id())
+
+occ = p.find_occurrences()
+occ.filter_none_type_issues()
+print(len(occ.occurrences))
+for occurrence in occ.occurrences:
+    print(occurrence.to_json_str())

--- a/src/android/profile.rs
+++ b/src/android/profile.rs
@@ -75,7 +75,7 @@ pub struct AndroidProfile {
 
     sampled: bool,
 
-    timestamp: DateTime<Utc>,
+    timestamp: Option<DateTime<Utc>>,
 
     trace_id: String,
 
@@ -147,6 +147,7 @@ impl ProfileInterface for AndroidProfile {
 
     fn get_timestamp(&self) -> DateTime<Utc> {
         self.timestamp
+            .unwrap_or(DateTime::from_timestamp(self.received, 0).unwrap())
     }
 
     fn normalize(&mut self) {
@@ -301,7 +302,7 @@ impl ProfileInterface for AndroidProfile {
             project_id: self.project_id.to_string(),
             sdk_name: self.client_sdk.as_ref().map(|sdk| sdk.name.clone()),
             sdk_version: self.client_sdk.as_ref().map(|sdk| sdk.version.clone()),
-            timestamp: self.timestamp.timestamp(),
+            timestamp: self.get_timestamp().timestamp(),
             trace_duration_ms: self.duration_ns as f64 / 1_000_000.0,
             transaction_id: self.transaction_id.clone(),
             transaction_name: self.transaction_name.clone(),


### PR DESCRIPTION
Android timestamp can sometimes be null.

In those cases, as we currently do in `vroom`, we should use `received` as a fallback.