### PR TITLE
fix: Stop classifying Sentry dylib as system frame

### DIFF
--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -12,8 +12,7 @@ static PACKAGE_EXTENSION_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\.(dylib|so|a|dll|exe)$").unwrap());
 static JS_SYSTEM_PACKAGE_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"node_modules|^(@moz-extension|chrome-extension)").unwrap());
-static COCOA_SYSTEM_PACKAGE: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| HashSet::from(["Sentry", "hermes"]));
+static COCOA_SYSTEM_PACKAGE: Lazy<HashSet<&'static str>> = Lazy::new(|| HashSet::from(["hermes"]));
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct Frame {
@@ -396,7 +395,7 @@ mod tests {
                     package: Some("/private/var/containers/Bundle/Application/00000000-0000-0000-0000-000000000000/App.app/Frameworks/Sentry.framework/Sentry".to_string()),
                     ..Default::default()
                 },
-                is_application: false,
+                is_application: true,
             }
         ];
 

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -1,6 +1,6 @@
 mod python_std_lib;
 
-use std::{collections::HashSet, hash::Hasher};
+use std::hash::Hasher;
 
 use fnv_rs::Fnv64;
 use once_cell::sync::Lazy;
@@ -12,7 +12,6 @@ static PACKAGE_EXTENSION_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\.(dylib|so|a|dll|exe)$").unwrap());
 static JS_SYSTEM_PACKAGE_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"node_modules|^(@moz-extension|chrome-extension)").unwrap());
-static COCOA_SYSTEM_PACKAGE: Lazy<HashSet<&'static str>> = Lazy::new(|| HashSet::from(["hermes"]));
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct Frame {
@@ -169,12 +168,6 @@ impl Frame {
         if is_main {
             // the main frame is found in the user package but should be treated
             // as a system frame as it does not contain any user code
-            return false;
-        }
-
-        // Some packages are known to be system packages.
-        // If we detect them, mark them as a system frame immediately.
-        if COCOA_SYSTEM_PACKAGE.contains(self.module_or_package().as_str()) {
             return false;
         }
 


### PR DESCRIPTION
We have this manual override that looks for Sentry.framework and turns it into a system frame. But it's not a system frame, it's shipped with the application. Also, if you link to the sentry SDK statically instead of dynamically the same code ends up classified as an application frame. For both these reasons I think it's a better user experience if we just report this as an application frame all the time, just like any other code in the .app. 

I'm not sure why "hermes" is in here also. Probably trying to treat the RN framework as a system library override also? It may make sense to remove this as well but I haven't used RN before so didn't want to make that change without someone with more RN experience checking

linking as a dylib, it's misclassified as a system frame:
<img width="2828" height="432" alt="Screenshot 2025-08-04 at 11 20 48 AM" src="https://github.com/user-attachments/assets/3d3920b6-8388-42d2-a057-8704f75d5b62" />

statically it ends up classified as an application frame:
<img width="2980" height="608" alt="Screenshot 2025-08-04 at 11 20 28 AM" src="https://github.com/user-attachments/assets/8b21b488-617b-4bdc-a01e-778deb401243" />


Edit: Updated to remove hermes from this override as well