### PR TITLE
feat: add support for stack fingerprint

### DIFF
--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -325,11 +325,14 @@ impl Frame {
         }
     }
 
-    pub fn fingerprint(&self) -> u32 {
+    pub fn fingerprint(&self, parent_fingerprint: Option<u32>) -> u32 {
         let mut hasher = Fnv64::default();
         hasher.write(self.module_or_package().as_bytes());
         hasher.write(":".as_bytes());
         hasher.write(self.function.as_deref().unwrap_or_default().as_bytes());
+        if let Some(parent_fingerprint) = parent_fingerprint {
+            hasher.write_u32(parent_fingerprint);
+        }
 
         // casting to an uint32 here because snuba does not handle uint64 values well
         // as it is converted to a float somewhere not changing to the 32 bit hash

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -291,13 +291,14 @@ impl Profile {
     ///     >>> metrics = profile.extract_functions_metrics(min_depth=2, filter_system_frames=True, max_unique_functions=10, filter_non_leaf_functions=False)
     ///     >>> for function_metric in metrics:
     ///     ...     do_something(function_metric)
-    #[pyo3(signature = (min_depth, filter_system_frames, max_unique_functions=None, filter_non_leaf_functions=true))]
+    #[pyo3(signature = (min_depth, filter_system_frames, max_unique_functions=None, filter_non_leaf_functions=true, generate_stack_fingerprints=false))]
     pub fn extract_functions_metrics(
         &mut self,
         min_depth: u16,
         filter_system_frames: bool,
         max_unique_functions: Option<usize>,
         filter_non_leaf_functions: bool,
+        generate_stack_fingerprints: bool,
     ) -> PyResult<Vec<CallTreeFunction>> {
         let call_trees: CallTreesU64 = self.profile.call_trees()?;
         let mut functions: HashMap<u32, CallTreeFunction> = HashMap::new();
@@ -309,7 +310,10 @@ impl Profile {
                     tid.to_string().as_ref(),
                     0,
                     min_depth,
+                    filter_system_frames,
                     filter_non_leaf_functions,
+                    generate_stack_fingerprints,
+                    None,
                 );
             }
         }

--- a/src/profile_chunk.rs
+++ b/src/profile_chunk.rs
@@ -271,13 +271,14 @@ impl ProfileChunk {
     ///     >>> metrics = profile_chunk.extract_functions_metrics(min_depth=2, filter_system_frames=True, max_unique_functions=10, filter_non_leaf_functions=False)
     ///     >>> for function_metric in metrics:
     ///     ...     do_something(function_metric)
-    #[pyo3(signature = (min_depth, filter_system_frames, max_unique_functions=None, filter_non_leaf_functions=true))]
+    #[pyo3(signature = (min_depth, filter_system_frames, max_unique_functions=None, filter_non_leaf_functions=true, generate_stack_fingerprints=false))]
     pub fn extract_functions_metrics(
         &mut self,
         min_depth: u16,
         filter_system_frames: bool,
         max_unique_functions: Option<usize>,
         filter_non_leaf_functions: bool,
+        generate_stack_fingerprints: bool,
     ) -> PyResult<Vec<CallTreeFunction>> {
         let call_trees: CallTreesStr = self.profile.call_trees(None)?;
         let mut functions: HashMap<u32, CallTreeFunction> = HashMap::new();
@@ -289,7 +290,10 @@ impl ProfileChunk {
                     tid,
                     0,
                     min_depth,
+                    filter_system_frames,
                     filter_non_leaf_functions,
+                    generate_stack_fingerprints,
+                    None,
                 );
             }
         }


### PR DESCRIPTION
If generate_stack_fingerprints is true, this will let us generate a fingerprint that keep tracks of the stack up to the current frame.

Parent fingerprint now, is also stored as part of the CallTreeFunction, so that we could potentially reconstruct the stack.