### PR TITLE
feat(chunk): Add attachments to profile chunks

### DIFF
--- a/src/android/chunk.rs
+++ b/src/android/chunk.rs
@@ -141,7 +141,6 @@ mod tests {
     use serde_path_to_error::Error;
 
     use super::AndroidChunk;
-    use crate::types::{Attachment, ChunkInterface};
 
     #[test]
     fn test_android_valid() {
@@ -149,31 +148,5 @@ mod tests {
         let d = &mut serde_json::Deserializer::from_slice(payload);
         let r: Result<AndroidChunk, Error<_>> = serde_path_to_error::deserialize(d);
         assert!(r.is_ok(), "{r:#?}")
-    }
-
-    #[test]
-    fn test_android_attachments_ignored() {
-        let payload = include_bytes!("../../tests/fixtures/android/chunk/valid.json");
-        let mut value: serde_json::Value = serde_json::from_slice(payload).unwrap();
-
-        // Attachments are only supported for sample chunks:
-        // the field is dropped on android chunks.
-        value["attachments"] = serde_json::json!([{
-            "name": "raw_profile",
-            "content_type": "application/x-perfetto",
-            "stored_id": "aef123345"
-        }]);
-        let mut chunk: AndroidChunk = serde_json::from_value(value).unwrap();
-        assert!(chunk.get_attachments().is_empty());
-        let serialized = serde_json::to_value(&chunk).unwrap();
-        assert!(serialized.get("attachments").is_none());
-
-        // The setter is a no-op.
-        chunk.set_attachments(vec![Attachment {
-            name: "raw_profile".to_string(),
-            content_type: Some("application/x-perfetto".to_string()),
-            stored_id: "aef123345".to_string(),
-        }]);
-        assert!(chunk.get_attachments().is_empty());
     }
 }

--- a/src/android/chunk.rs
+++ b/src/android/chunk.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     nodetree::Node,
-    types::{CallTreeError, CallTreesStr, ChunkInterface, ClientSDK, DebugMeta},
+    types::{Attachment, CallTreeError, CallTreesStr, ChunkInterface, ClientSDK, DebugMeta},
 };
 
 use super::Android;
@@ -79,6 +79,14 @@ impl ChunkInterface for AndroidChunk {
         self.project_id
     }
 
+    // Attachments are only supported for sample chunks:
+    // the getter always returns an empty list and the setter is a no-op.
+    fn get_attachments(&self) -> &[Attachment] {
+        &[]
+    }
+
+    fn set_attachments(&mut self, _attachments: Vec<Attachment>) {}
+
     fn get_received(&self) -> f64 {
         self.received
     }
@@ -133,6 +141,7 @@ mod tests {
     use serde_path_to_error::Error;
 
     use super::AndroidChunk;
+    use crate::types::{Attachment, ChunkInterface};
 
     #[test]
     fn test_android_valid() {
@@ -140,5 +149,31 @@ mod tests {
         let d = &mut serde_json::Deserializer::from_slice(payload);
         let r: Result<AndroidChunk, Error<_>> = serde_path_to_error::deserialize(d);
         assert!(r.is_ok(), "{r:#?}")
+    }
+
+    #[test]
+    fn test_android_attachments_ignored() {
+        let payload = include_bytes!("../../tests/fixtures/android/chunk/valid.json");
+        let mut value: serde_json::Value = serde_json::from_slice(payload).unwrap();
+
+        // Attachments are only supported for sample chunks:
+        // the field is dropped on android chunks.
+        value["attachments"] = serde_json::json!([{
+            "name": "raw_profile",
+            "content_type": "application/x-perfetto",
+            "stored_id": "aef123345"
+        }]);
+        let mut chunk: AndroidChunk = serde_json::from_value(value).unwrap();
+        assert!(chunk.get_attachments().is_empty());
+        let serialized = serde_json::to_value(&chunk).unwrap();
+        assert!(serialized.get("attachments").is_none());
+
+        // The setter is a no-op.
+        chunk.set_attachments(vec![Attachment {
+            name: "raw_profile".to_string(),
+            content_type: Some("application/x-perfetto".to_string()),
+            stored_id: "aef123345".to_string(),
+        }]);
+        assert!(chunk.get_attachments().is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ fn decompress_profile(profile: &[u8]) -> PyResult<Profile> {
 fn vroomrs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ProfileChunk>()?;
     m.add_class::<CallTreeFunction>()?;
+    m.add_class::<types::Attachment>()?;
     m.add_function(wrap_pyfunction!(profile_chunk_from_json_str, m)?)?;
     m.add_function(wrap_pyfunction!(decompress_profile_chunk, m)?)?;
     m.add_function(wrap_pyfunction!(profile_from_json_str, m)?)?;

--- a/src/profile_chunk.rs
+++ b/src/profile_chunk.rs
@@ -18,43 +18,50 @@ pub struct ProfileChunk {
 
 #[derive(serde::Deserialize)]
 struct MinimumProfile {
+    #[serde(default)]
+    platform: String,
     version: Option<String>,
+    // Present only on legacy android profiles: the raw, unparsed profile.
+    // Ignored here, we only care whether it's set.
+    sampled_profile: Option<serde::de::IgnoredAny>,
 }
 
 impl ProfileChunk {
     pub(crate) fn from_json_vec(profile: &[u8]) -> Result<Self, serde_json::Error> {
         let min_prof: MinimumProfile = serde_json::from_slice(profile)?;
-        match min_prof.version {
-            None => {
-                let android: AndroidChunk = serde_json::from_slice(profile)?;
-                Ok(ProfileChunk {
-                    profile: Box::new(android),
-                })
-            }
-            Some(_) => {
-                let sample: SampleChunk = serde_json::from_slice(profile)?;
-                Ok(ProfileChunk {
-                    profile: Box::new(sample),
-                })
-            }
-        }
+        Self::from_json_vec_with_profile(profile, &min_prof.platform, &min_prof)
     }
 
     pub(crate) fn from_json_vec_and_platform(
         profile: &[u8],
         platform: &str,
     ) -> Result<Self, serde_json::Error> {
-        match platform {
-            // Only profiles without a version use the legacy android format:
-            // android profiles with a version (e.g. "2") use the sample format,
-            // so we fall back to version-based detection.
-            "android" => Self::from_json_vec(profile),
-            _ => {
-                let sample: SampleChunk = serde_json::from_slice(profile)?;
-                Ok(ProfileChunk {
-                    profile: Box::new(sample),
-                })
-            }
+        let min_prof: MinimumProfile = serde_json::from_slice(profile)?;
+        Self::from_json_vec_with_profile(profile, platform, &min_prof)
+    }
+
+    fn from_json_vec_with_profile(
+        profile: &[u8],
+        platform: &str,
+        min_prof: &MinimumProfile,
+    ) -> Result<Self, serde_json::Error> {
+        // A chunk is a legacy android chunk when its platform is android and it
+        // either carries no version (the original legacy format) or still contains
+        // a `sampled_profile`. The latter is an interim fix: some legacy android
+        // profiles are sent with version "2" even though they don't follow the
+        // sample v2 format.
+        let is_legacy_android = platform == "android"
+            && (min_prof.version.is_none() || min_prof.sampled_profile.is_some());
+        if is_legacy_android {
+            let android: AndroidChunk = serde_json::from_slice(profile)?;
+            Ok(ProfileChunk {
+                profile: Box::new(android),
+            })
+        } else {
+            let sample: SampleChunk = serde_json::from_slice(profile)?;
+            Ok(ProfileChunk {
+                profile: Box::new(sample),
+            })
         }
     }
 
@@ -415,6 +422,29 @@ mod tests {
             .as_any()
             .downcast_ref::<AndroidChunk>()
             .is_some());
+    }
+
+    #[test]
+    fn test_legacy_android_with_sampled_profile_is_android_chunk() {
+        // Interim fix: some legacy android profiles are sent with a version
+        // (e.g. "2") even though they carry a `sampled_profile` and don't
+        // follow the sample v2 format. They must be treated as android chunks.
+        let payload = include_bytes!("../tests/fixtures/android/chunk/valid.json");
+        let mut value: serde_json::Value = serde_json::from_slice(payload).unwrap();
+        value["version"] = "2".into();
+        value["sampled_profile"] = "AAAAA".into();
+        let json = serde_json::to_vec(&value).unwrap();
+
+        for chunk in [
+            ProfileChunk::from_json_vec(&json).unwrap(),
+            ProfileChunk::from_json_vec_and_platform(&json, "android").unwrap(),
+        ] {
+            assert!(chunk
+                .profile
+                .as_any()
+                .downcast_ref::<AndroidChunk>()
+                .is_some());
+        }
     }
 
     #[test]

--- a/src/profile_chunk.rs
+++ b/src/profile_chunk.rs
@@ -6,7 +6,7 @@ use crate::{
     android::chunk::AndroidChunk,
     nodetree::CallTreeFunction,
     sample::v2::SampleChunk,
-    types::{CallTreesStr, ChunkInterface},
+    types::{Attachment, CallTreesStr, ChunkInterface},
     utils::{compress_lz4, decompress_lz4},
 };
 
@@ -45,12 +45,10 @@ impl ProfileChunk {
         platform: &str,
     ) -> Result<Self, serde_json::Error> {
         match platform {
-            "android" => {
-                let android: AndroidChunk = serde_json::from_slice(profile)?;
-                Ok(ProfileChunk {
-                    profile: Box::new(android),
-                })
-            }
+            // Only profiles without a version use the legacy android format:
+            // android profiles with a version (e.g. "2") use the sample format,
+            // so we fall back to version-based detection.
+            "android" => Self::from_json_vec(profile),
             _ => {
                 let sample: SampleChunk = serde_json::from_slice(profile)?;
                 Ok(ProfileChunk {
@@ -127,6 +125,28 @@ impl ProfileChunk {
     ///         The project ID to which the profile belongs.
     pub fn get_project_id(&self) -> u64 {
         self.profile.get_project_id()
+    }
+
+    /// Returns the attachments related to this chunk.
+    ///
+    /// Returns:
+    ///     list[Attachment]
+    ///         The attachments (e.g. a raw profile) related to this chunk.
+    ///         Empty if no attachments are available.
+    pub fn get_attachments(&self) -> Vec<Attachment> {
+        self.profile.get_attachments().to_vec()
+    }
+
+    /// Sets the attachments related to this chunk.
+    ///
+    /// Attachments are only supported for sample chunks:
+    /// this is a no-op for Android chunks.
+    ///
+    /// Args:
+    ///     attachments (list[Attachment]): The attachments related to this
+    ///         chunk, replacing any existing ones. An empty list clears them.
+    pub fn set_attachments(&mut self, attachments: Vec<Attachment>) {
+        self.profile.set_attachments(attachments);
     }
 
     /// Returns the received timestamp.
@@ -363,6 +383,60 @@ mod tests {
                 test.name
             )
         }
+    }
+
+    #[test]
+    fn test_android_platform_with_version_is_sample_chunk() {
+        // A chunk with platform=android but a version set uses the
+        // sample v2 format and must not be treated as a legacy
+        // android chunk, no matter how it's deserialized.
+        let payload = include_bytes!("../tests/fixtures/sample/v2/valid_cocoa.json");
+        let mut value: serde_json::Value = serde_json::from_slice(payload).unwrap();
+        value["platform"] = "android".into();
+        let json = serde_json::to_vec(&value).unwrap();
+
+        for chunk in [
+            ProfileChunk::from_json_vec(&json).unwrap(),
+            ProfileChunk::from_json_vec_and_platform(&json, "android").unwrap(),
+        ] {
+            assert_eq!(chunk.get_platform(), "android");
+            assert!(chunk
+                .profile
+                .as_any()
+                .downcast_ref::<SampleChunk>()
+                .is_some());
+        }
+
+        // Legacy android chunks (no version) still deserialize as such.
+        let payload = include_bytes!("../tests/fixtures/android/chunk/valid.json");
+        let chunk = ProfileChunk::from_json_vec_and_platform(payload, "android").unwrap();
+        assert!(chunk
+            .profile
+            .as_any()
+            .downcast_ref::<AndroidChunk>()
+            .is_some());
+    }
+
+    #[test]
+    fn test_attachments_survive_compression() {
+        use crate::types::Attachment;
+
+        // The sentry writer flow: deserialize the chunk, stamp the
+        // attachments, compress and store. The attachments must survive
+        // into the stored chunk representation.
+        let payload = include_bytes!("../tests/fixtures/sample/v2/valid_cocoa.json");
+        let mut chunk = ProfileChunk::from_json_vec(payload).unwrap();
+        let attachments = vec![Attachment {
+            name: "raw_profile".to_string(),
+            content_type: Some("application/x-perfetto".to_string()),
+            stored_id: "aef123345".to_string(),
+        }];
+        chunk.set_attachments(attachments.clone());
+        assert_eq!(chunk.get_attachments(), attachments);
+
+        let compressed = chunk.compress().unwrap();
+        let decompressed = ProfileChunk::decompress(compressed.as_slice()).unwrap();
+        assert_eq!(decompressed.get_attachments(), attachments);
     }
 
     #[test]

--- a/src/sample/v2.rs
+++ b/src/sample/v2.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use super::{SampleError, ThreadMetadata};
 use crate::frame::Frame;
 use crate::nodetree::Node;
-use crate::types::{CallTreeError, CallTreesStr, ChunkInterface};
+use crate::types::{Attachment, CallTreeError, CallTreesStr, ChunkInterface};
 use crate::types::{ClientSDK, DebugMeta};
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
@@ -46,6 +46,9 @@ pub struct SampleChunk {
     // `measurements` contains CPU/memory measurements we do during the capture of the chunk.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub measurements: Option<serde_json::Value>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<Attachment>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
@@ -243,6 +246,14 @@ impl ChunkInterface for SampleChunk {
         self.project_id
     }
 
+    fn get_attachments(&self) -> &[Attachment] {
+        &self.attachments
+    }
+
+    fn set_attachments(&mut self, attachments: Vec<Attachment>) {
+        self.attachments = attachments;
+    }
+
     fn get_received(&self) -> f64 {
         self.received
     }
@@ -329,6 +340,53 @@ mod tests {
         let d = &mut serde_json::Deserializer::from_slice(payload);
         let r: Result<SampleChunk, Error<_>> = serde_path_to_error::deserialize(d);
         assert!(r.is_ok(), "{r:#?}")
+    }
+
+    #[test]
+    fn test_attachments() {
+        use crate::types::Attachment;
+
+        let payload = include_bytes!("../../tests/fixtures/sample/v2/valid_cocoa.json");
+        let mut value: serde_json::Value = serde_json::from_slice(payload).unwrap();
+
+        // An absent field deserializes to an empty list,
+        // which is skipped during serialization.
+        let chunk: SampleChunk = serde_json::from_value(value.clone()).unwrap();
+        assert!(chunk.attachments.is_empty());
+        let serialized = serde_json::to_value(&chunk).unwrap();
+        assert!(serialized.get("attachments").is_none());
+
+        // A present field round-trips.
+        let attachments_json = serde_json::json!([{
+            "name": "raw_profile",
+            "content_type": "application/x-perfetto",
+            "stored_id": "aef123345"
+        }]);
+        value["attachments"] = attachments_json.clone();
+        let mut chunk: SampleChunk = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            chunk.get_attachments(),
+            &[Attachment {
+                name: "raw_profile".to_string(),
+                content_type: Some("application/x-perfetto".to_string()),
+                stored_id: "aef123345".to_string(),
+            }]
+        );
+        let serialized = serde_json::to_value(&chunk).unwrap();
+        assert_eq!(serialized["attachments"], attachments_json);
+
+        // The setter overwrites and clears the list.
+        chunk.set_attachments(vec![Attachment {
+            name: "raw_profile".to_string(),
+            content_type: None,
+            stored_id: "fff999".to_string(),
+        }]);
+        assert_eq!(chunk.get_attachments()[0].stored_id, "fff999");
+        assert_eq!(chunk.get_attachments()[0].content_type, None);
+        chunk.set_attachments(Vec::new());
+        assert!(chunk.get_attachments().is_empty());
+        let serialized = serde_json::to_value(&chunk).unwrap();
+        assert!(serialized.get("attachments").is_none());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -113,11 +113,17 @@ pub trait ChunkInterface {
 #[pyclass(eq)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Attachment {
+    /// The name of the attachment (e.g. `raw_profile`).
     #[pyo3(get)]
     pub name: String,
+    /// The MIME content type of the attachment (e.g. `application/x-perfetto`), if known.
+    ///
+    /// Intentionally kept as a free-form string for now to stay open to new
+    /// content types; it is passed through and not interpreted within this repo.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[pyo3(get)]
     pub content_type: Option<String>,
+    /// The identifier of the attachment in the object store.
     #[pyo3(get)]
     pub stored_id: String,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 
 use pyo3::exceptions::PyValueError;
-use pyo3::{pyclass, PyErr};
+use pyo3::{pyclass, pymethods, PyErr};
 use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::borrow::Cow;
@@ -83,6 +83,8 @@ pub trait ChunkInterface {
     fn get_platform(&self) -> String;
     fn get_profiler_id(&self) -> &str;
     fn get_project_id(&self) -> u64;
+    fn get_attachments(&self) -> &[Attachment];
+    fn set_attachments(&mut self, attachments: Vec<Attachment>);
     fn get_received(&self) -> f64;
     fn get_release(&self) -> Option<&str>;
     fn get_retention_days(&self) -> i32;
@@ -105,6 +107,44 @@ pub trait ChunkInterface {
     fn to_json_vec(&self) -> Result<Vec<u8>, serde_json::Error>;
 
     fn as_any(&self) -> &dyn Any;
+}
+
+/// A file related to the chunk (e.g. a raw profile), stored in the object store.
+#[pyclass(eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Attachment {
+    #[pyo3(get)]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[pyo3(get)]
+    pub content_type: Option<String>,
+    #[pyo3(get)]
+    pub stored_id: String,
+}
+
+#[pymethods]
+impl Attachment {
+    #[new]
+    #[pyo3(signature = (name, content_type, stored_id))]
+    fn new(name: String, content_type: Option<String>, stored_id: String) -> Self {
+        Attachment {
+            name,
+            content_type,
+            stored_id,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Attachment(name={:?}, content_type={}, stored_id={:?})",
+            self.name,
+            match &self.content_type {
+                Some(content_type) => format!("{content_type:?}"),
+                None => "None".to_string(),
+            },
+            self.stored_id
+        )
+    }
 }
 
 #[pyclass]

--- a/src/types.rs
+++ b/src/types.rs
@@ -113,7 +113,7 @@ pub trait ChunkInterface {
 #[pyclass(eq)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Attachment {
-    /// The name of the attachment (e.g. `raw_profile`).
+    /// The attachment file name, e.g. `raw_profile.pftrace`.
     #[pyo3(get)]
     pub name: String,
     /// The MIME content type of the attachment (e.g. `application/x-perfetto`), if known.

--- a/vroomrs.pyi
+++ b/vroomrs.pyi
@@ -489,7 +489,7 @@ class Attachment:
     """
 
     name: str
-    """The attachment kind, e.g. `raw_profile`."""
+    """The attachment file name, e.g. `raw_profile.pftrace`."""
 
     content_type: Optional[str]
     """The content type of the attachment, or None if not available."""

--- a/vroomrs.pyi
+++ b/vroomrs.pyi
@@ -316,7 +316,30 @@ class ProfileChunk:
             int: The project ID to which the profile belongs.
         """
         ...
-    
+
+    def get_attachments(self) -> List["Attachment"]:
+        """
+        Returns the attachments related to this chunk.
+
+        Returns:
+            list[Attachment]: The attachments (e.g. a raw profile) related
+                to this chunk. Empty if no attachments are available.
+        """
+        ...
+
+    def set_attachments(self, attachments: List["Attachment"]) -> None:
+        """
+        Sets the attachments related to this chunk.
+
+        Attachments are only supported for sample chunks:
+        this is a no-op for Android chunks.
+
+        Args:
+            attachments (list[Attachment]): The attachments related to this
+                chunk, replacing any existing ones. An empty list clears them.
+        """
+        ...
+
     def get_received(self) -> float:
         """
         Returns the received timestamp.
@@ -325,7 +348,7 @@ class ProfileChunk:
             float: The received timestamp.
         """
         ...
-    
+
     def get_release(self) -> Optional[str]:
         """
         Returns the release.
@@ -459,6 +482,22 @@ class ProfileChunk:
             ...     do_something(function_metric)
         """
         ...
+
+class Attachment:
+    """
+    A file related to the chunk (e.g. a raw profile), stored in the object store.
+    """
+
+    name: str
+    """The attachment kind, e.g. `raw_profile`."""
+
+    content_type: Optional[str]
+    """The content type of the attachment, or None if not available."""
+
+    stored_id: str
+    """The object store ID of the attachment."""
+
+    def __init__(self, name: str, content_type: Optional[str], stored_id: str) -> None: ...
 
 class CallTreeFunction:
     """


### PR DESCRIPTION
Adds a generic `attachments` list to profile chunks, exposed through the Python API. Each attachment references a file stored in the object store — e.g. a raw perfetto trace kept alongside the Sentry-processed chunk — with a `name` (file name), an optional `content_type`, and a `stored_id`:

```python
chunk.set_attachments([vroomrs.Attachment("raw_profile.pftrace", "application/x-perfetto", "aef123345")])
chunk.get_attachments()  # -> list[Attachment]
```

## What changed

- New `Attachment` pyclass plus `get_attachments` / `set_attachments` on `ProfileChunk`, with matching `.pyi` stubs.
- `attachments` is added to the sample-v2 chunk format; it is omitted from JSON when empty.
- `content_type` is intentionally a free-form string for now; it is passed through and not interpreted within this repo.

## Changed treatment of legacy Android profiles

Chunk-format detection is now unified: `from_json_vec` and `from_json_vec_and_platform` share a single detection path that parses the minimum profile once. A chunk is treated as a **legacy Android chunk** when:

```
platform == "android" && (version is absent || sampled_profile is present)
```

Two consequences:

- **Android sample-v2 chunks are no longer misrouted.** An android chunk that carries a `version` (and no `sampled_profile`) is now parsed as a sample-v2 chunk instead of the legacy Android format. This is required for android sample-v2 chunks to support attachments at all.
- **Interim fix for malformed legacy profiles.** Some legacy Android profiles are sent with `version` set to `"2"` even though they don't follow the sample-v2 format. The `sampled_profile` check keeps these routed to the legacy Android format so they still parse correctly.

## Design notes for reviewers

- Attachments are sample-v2-only: the getter returns an empty list and the setter is a no-op on legacy Android-format chunks.
- `set_attachments` replaces the whole list rather than appending, so it stays idempotent if the processing task retries.

This is the writer/in-process half of the cross-repo feature; the Go read path lives in getsentry/vroom#670 and the kafka message contract in sentry-kafka-schemas. Needs a vroomrs release + pin bump in sentry once it lands.
