### PR TITLE
feat(chunks): classify android in-app frames and trim synthetic frames

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -528,7 +528,7 @@ impl Android {
                 i -= 1;
             }
         }
-        for (_, trees) in trees_by_thread_id.iter() {
+        for trees in trees_by_thread_id.values() {
             for root in trees {
                 root.borrow_mut().close(max_timestamp_ns);
             }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -68,6 +68,46 @@ pub struct Frame {
     pub is_react_native: bool,
 }
 
+/// Determines whether an android frame's package points at an OS/runtime
+/// location. Package paths appear both with and without a leading slash (e.g.
+/// "system/lib64/libhwui.so" and "/system/..."), so we strip one before matching.
+pub(crate) fn is_android_system_package(package: &str) -> bool {
+    let norm = package.strip_prefix('/').unwrap_or(package);
+    norm.starts_with("system/")
+        || norm.starts_with("vendor/")
+        || norm.starts_with("apex/")
+        || package == "[vdso]"
+        || package == "[stack]"
+        || package.starts_with("[anon:dalvik-")
+}
+
+/// Platform, runtime and SDK class-name namespaces for android/JVM frames. A
+/// frame whose class (module) starts with one of these is a system frame;
+/// everything else — the app's own code and its bundled libraries are application code.
+/// `io.sentry.` is our own instrumentation, treated as
+/// system, like we do for python and cocoa.
+const ANDROID_SYSTEM_MODULE_PREFIXES: &[&str] = &[
+    "java.",
+    "javax.",
+    "kotlin.",
+    "kotlinx.",
+    "android.",
+    "com.android.",
+    "dalvik.",
+    "libcore.",
+    "sun.",
+    "jdk.",
+    "io.sentry.",
+];
+
+/// Determines whether an android/JVM class name belongs to a platform, runtime
+/// or SDK namespace (i.e. not the application's own code).
+pub(crate) fn is_android_system_module(name: &str) -> bool {
+    ANDROID_SYSTEM_MODULE_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+}
+
 /// Determines whether the image represents that of the application
 /// binary (or a binary embedded in the application binary) by checking its package path.
 pub fn is_cocoa_application_package(p: &str) -> bool {
@@ -239,6 +279,38 @@ impl Frame {
             .is_none_or(|path| !path.contains("/vendor/"))
     }
 
+    fn is_android_application_frame(&self) -> bool {
+        if self
+            .package
+            .as_deref()
+            .is_some_and(is_android_system_package)
+        {
+            return false;
+        }
+
+        let symbol = self
+            .module
+            .as_deref()
+            .filter(|m| !m.is_empty())
+            .or(self.function.as_deref())
+            .unwrap_or_default();
+        !is_android_system_module(symbol)
+    }
+
+    /// Whether the frame is synthetic noise that's dropped from android profiles,
+    /// mirroring sentry-java's TombstoneParser:
+    /// - ART runtime/interpreter frames (libart.so), not actionable for developers.
+    /// - anonymous VMA frames with no function name, which can't be symbolicated
+    ///   and have no value in themselves.
+    pub(crate) fn is_synthetic_android_frame(&self) -> bool {
+        let Some(package) = self.package.as_deref() else {
+            return false;
+        };
+        package.ends_with("libart.so")
+            || (package.starts_with("<anonymous")
+                && self.function.as_deref().is_none_or(str::is_empty))
+    }
+
     fn set_in_app(&mut self, p: &str) {
         // for react-native the in_app field seems to be messed up most of the times,
         // with system libraries and other frames that are clearly system frames
@@ -259,6 +331,9 @@ impl Frame {
             "rust" => self.is_rust_application_frame(),
             "python" => self.is_python_application_frame(),
             "php" => self.is_php_application_frame(),
+            "java" | "native" | "android" if p == "android" => self
+                .in_app
+                .unwrap_or_else(|| self.is_android_application_frame()),
             _ => false,
         };
 
@@ -877,5 +952,345 @@ mod tests {
                 test_case.name, s1, s2
             );
         }
+    }
+
+    #[test]
+    fn test_is_android_application_frame_by_package() {
+        struct TestStruct {
+            name: String,
+            frame: Frame,
+            is_application: bool,
+        }
+
+        // Native/library frames are classified by their package location.
+        let test_cases = vec![
+            TestStruct {
+                name: "no package -> unresolved, application".to_string(),
+                frame: Frame {
+                    ..Default::default()
+                },
+                is_application: true,
+            },
+            TestStruct {
+                name: "empty package -> application".to_string(),
+                frame: Frame {
+                    package: Some("".to_string()),
+                    ..Default::default()
+                },
+                is_application: true,
+            },
+            TestStruct {
+                name: "system lib".to_string(),
+                frame: Frame {
+                    package: Some("system/lib64/libhwui.so".to_string()),
+                    ..Default::default()
+                },
+                is_application: false,
+            },
+            TestStruct {
+                name: "system framework jar with leading slash".to_string(),
+                frame: Frame {
+                    package: Some("/system/framework/framework.jar".to_string()),
+                    ..Default::default()
+                },
+                is_application: false,
+            },
+            TestStruct {
+                name: "vendor lib".to_string(),
+                frame: Frame {
+                    package: Some("vendor/lib64/libGLESv2_enc.so".to_string()),
+                    ..Default::default()
+                },
+                is_application: false,
+            },
+            TestStruct {
+                name: "apex runtime lib".to_string(),
+                frame: Frame {
+                    package: Some("apex/com.android.runtime/lib64/bionic/libc.so".to_string()),
+                    ..Default::default()
+                },
+                is_application: false,
+            },
+            TestStruct {
+                name: "vdso".to_string(),
+                frame: Frame {
+                    package: Some("[vdso]".to_string()),
+                    ..Default::default()
+                },
+                is_application: false,
+            },
+            TestStruct {
+                name: "dalvik heap region".to_string(),
+                frame: Frame {
+                    package: Some("[anon:dalvik-LinearAlloc]".to_string()),
+                    ..Default::default()
+                },
+                is_application: false,
+            },
+        ];
+        for test_case in test_cases {
+            let is_app = test_case.frame.is_android_application_frame();
+            assert_eq!(
+                is_app, test_case.is_application,
+                "test: {}\nexpected: {} - got: {}",
+                test_case.name, test_case.is_application, is_app
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_android_application_frame_by_module() {
+        struct TestStruct {
+            name: String,
+            frame: Frame,
+            is_application: bool,
+        }
+
+        // JVM frames are classified by their class namespace, taken from `module`
+        // (or `function` when the module is absent, e.g. deobfuscated frames). The
+        // JIT code cache package must not sway the result.
+        let jit = "[anon_shmem:dalvik-jit-code-cache]";
+        let by_module = |module: &str| Frame {
+            package: Some(jit.to_string()),
+            module: Some(module.to_string()),
+            ..Default::default()
+        };
+        let by_function = |function: &str| Frame {
+            function: Some(function.to_string()),
+            ..Default::default()
+        };
+
+        let test_cases = vec![
+            // platform / runtime / stdlib -> system
+            TestStruct {
+                name: "java stdlib".to_string(),
+                frame: by_module("java.util.HashMap"),
+                is_application: false,
+            },
+            TestStruct {
+                name: "android platform".to_string(),
+                frame: by_module("android.view.View"),
+                is_application: false,
+            },
+            TestStruct {
+                name: "com.android internal".to_string(),
+                frame: by_module("com.android.internal.os.ZygoteInit"),
+                is_application: false,
+            },
+            TestStruct {
+                name: "libcore".to_string(),
+                frame: by_module("libcore.io.Linux"),
+                is_application: false,
+            },
+            TestStruct {
+                name: "sun".to_string(),
+                frame: by_module("sun.nio.ch.FileChannelImpl"),
+                is_application: false,
+            },
+            TestStruct {
+                name: "kotlin stdlib".to_string(),
+                frame: by_module("kotlin.collections.ArraysKt"),
+                is_application: false,
+            },
+            // the Sentry SDK is our own instrumentation -> system
+            TestStruct {
+                name: "sentry sdk".to_string(),
+                frame: by_module("io.sentry.transport.AsyncHttpTransport"),
+                is_application: false,
+            },
+            // the app and its bundled libraries (androidx, third-party) -> application
+            TestStruct {
+                name: "app code".to_string(),
+                frame: by_module("com.example.MainActivity"),
+                is_application: true,
+            },
+            TestStruct {
+                name: "androidx ships with the app".to_string(),
+                frame: by_module("androidx.recyclerview.widget.RecyclerView"),
+                is_application: true,
+            },
+            TestStruct {
+                name: "bundled gson".to_string(),
+                frame: by_module("com.google.gson.Gson"),
+                is_application: true,
+            },
+            TestStruct {
+                name: "bundled rxjava".to_string(),
+                frame: by_module("rx.internal.operators.OperatorMap"),
+                is_application: true,
+            },
+            // FQN in `function` when `module` is absent (deobfuscated frames)
+            TestStruct {
+                name: "system fqn in function".to_string(),
+                frame: by_function("android.os.Handler.dispatchMessage"),
+                is_application: false,
+            },
+            TestStruct {
+                name: "app fqn in function".to_string(),
+                frame: by_function("com.example.HomeActivity.onCreate"),
+                is_application: true,
+            },
+            // A bare method name (no namespace, e.g. an unattributed native
+            // symbol) matches no system prefix and defaults to application.
+            TestStruct {
+                name: "bare method name in function".to_string(),
+                frame: by_function("malloc"),
+                is_application: true,
+            },
+        ];
+        for test_case in test_cases {
+            let is_app = test_case.frame.is_android_application_frame();
+            assert_eq!(
+                is_app, test_case.is_application,
+                "test: {}\nexpected: {} - got: {}",
+                test_case.name, test_case.is_application, is_app
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_synthetic_android_frame() {
+        struct TestStruct {
+            name: String,
+            frame: Frame,
+            is_synthetic: bool,
+        }
+
+        let test_cases = vec![
+            TestStruct {
+                name: "libart runtime".to_string(),
+                frame: Frame {
+                    package: Some("apex/com.android.art/lib64/libart.so".to_string()),
+                    ..Default::default()
+                },
+                is_synthetic: true,
+            },
+            TestStruct {
+                name: "libart with leading slash".to_string(),
+                frame: Frame {
+                    package: Some("/apex/com.android.art/lib64/libart.so".to_string()),
+                    ..Default::default()
+                },
+                is_synthetic: true,
+            },
+            TestStruct {
+                name: "other lib in the art apex".to_string(),
+                frame: Frame {
+                    package: Some("apex/com.android.art/lib64/libjavacore.so".to_string()),
+                    ..Default::default()
+                },
+                is_synthetic: false,
+            },
+            TestStruct {
+                name: "unrelated system lib".to_string(),
+                frame: Frame {
+                    package: Some("system/lib64/libhwui.so".to_string()),
+                    ..Default::default()
+                },
+                is_synthetic: false,
+            },
+            TestStruct {
+                name: "anonymous VMA without a function name".to_string(),
+                frame: Frame {
+                    package: Some("<anonymous:7f8a0000>".to_string()),
+                    ..Default::default()
+                },
+                is_synthetic: true,
+            },
+            TestStruct {
+                name: "anonymous VMA with an empty function name".to_string(),
+                frame: Frame {
+                    package: Some("<anonymous:7f8a0000>".to_string()),
+                    function: Some("".to_string()),
+                    ..Default::default()
+                },
+                is_synthetic: true,
+            },
+            TestStruct {
+                name: "anonymous VMA with a resolved function name".to_string(),
+                frame: Frame {
+                    package: Some("<anonymous:7f8a0000>".to_string()),
+                    function: Some("doWork".to_string()),
+                    ..Default::default()
+                },
+                is_synthetic: false,
+            },
+            TestStruct {
+                name: "no package".to_string(),
+                frame: Frame {
+                    ..Default::default()
+                },
+                is_synthetic: false,
+            },
+        ];
+        for test_case in test_cases {
+            let is_synthetic = test_case.frame.is_synthetic_android_frame();
+            assert_eq!(
+                is_synthetic, test_case.is_synthetic,
+                "test: {}\nexpected: {} - got: {}",
+                test_case.name, test_case.is_synthetic, is_synthetic
+            );
+        }
+    }
+
+    #[test]
+    fn test_set_in_app_android_computes_when_absent() {
+        // When in_app is absent, set_in_app populates it from the package/module.
+        // Native frames are classified by their package.
+        let mut sys = Frame {
+            platform: Some("native".to_string()),
+            package: Some("system/lib64/libhwui.so".to_string()),
+            ..Default::default()
+        };
+        sys.normalize("android");
+        assert_eq!(sys.in_app, Some(false));
+
+        // Untyped frames (platform absent) default to the "android" platform and
+        // are still classified — this is how relay delivers JVM frames.
+        let mut untyped_app = Frame {
+            function: Some("com.example.MainActivity.onCreate".to_string()),
+            ..Default::default()
+        };
+        untyped_app.normalize("android");
+        assert_eq!(untyped_app.in_app, Some(true));
+
+        let mut untyped_sys = Frame {
+            module: Some("android.os.Handler".to_string()),
+            ..Default::default()
+        };
+        untyped_sys.normalize("android");
+        assert_eq!(untyped_sys.in_app, Some(false));
+
+        // JVM frames ("java") are classified by their class module.
+        let mut framework = Frame {
+            platform: Some("java".to_string()),
+            module: Some("android.os.Handler".to_string()),
+            ..Default::default()
+        };
+        framework.normalize("android");
+        assert_eq!(framework.in_app, Some(false));
+    }
+
+    #[test]
+    fn test_set_in_app_android_preserves_existing_in_app() {
+        // Relay already computes in_app; an existing value is trusted and never
+        // overridden, mirroring the legacy android format (in_app.or_else(compute)).
+        // This holds even when our own rules would classify the frame differently.
+        let mut app = Frame {
+            platform: Some("native".to_string()),
+            function: Some("com.example.MainActivity.onCreate".to_string()),
+            in_app: Some(false), // our rules would say true, but relay wins
+            ..Default::default()
+        };
+        app.normalize("android");
+        assert_eq!(app.in_app, Some(false));
+
+        let mut sys = Frame {
+            module: Some("android.os.Handler".to_string()),
+            in_app: Some(true), // our rules would say false, but relay wins
+            ..Default::default()
+        };
+        sys.normalize("android");
+        assert_eq!(sys.in_app, Some(true));
     }
 }

--- a/src/sample/v2.rs
+++ b/src/sample/v2.rs
@@ -58,6 +58,48 @@ pub struct SampleData {
 }
 
 impl SampleData {
+    /// Drops synthetic android frames (ART runtime, unsymbolicatable anonymous
+    /// frames) and re-indexes the stacks that reference them, compacting both
+    /// vectors in place. Samples reference stacks by id, so they're unaffected.
+    fn trim_android_stacks(&mut self) {
+        let mut next_index: i32 = 0;
+        // format: index_map[old_index] -> new_index or None if synthetic
+        let index_map: Vec<Option<i32>> = self
+            .frames
+            .iter()
+            .map(|frame| {
+                if frame.is_synthetic_android_frame() {
+                    None
+                } else {
+                    let index = next_index;
+                    next_index += 1;
+                    Some(index)
+                }
+            })
+            .collect();
+
+        if next_index as usize == self.frames.len() {
+            return; // no synthetic frames present
+        }
+
+        // Drop synthetic frames from stacks
+        for stack in &mut self.stacks {
+            stack.retain_mut(|id| match index_map.get(*id as usize) {
+                Some(Some(new_index)) => {
+                    *id = *new_index;
+                    true
+                }
+                Some(None) => false,
+                None => true, // out of range; leave for call_trees to reject
+            });
+        }
+
+        // Drop the synthetic frames themselves in-place.
+        let mut frame_indices = index_map.iter();
+        self.frames
+            .retain(|_| frame_indices.next().unwrap().is_some());
+    }
+
     fn trim_python_stacks(&mut self) {
         // Find the module frame index in frames
         let module_frame_index = self.frames.iter().position(|f| {
@@ -211,6 +253,9 @@ impl ChunkInterface for SampleChunk {
     }
 
     fn normalize(&mut self) {
+        if self.platform.as_str() == "android" {
+            self.profile.trim_android_stacks();
+        }
         for frame in &mut self.profile.frames {
             frame.normalize(&self.platform);
         }
@@ -677,5 +722,142 @@ mod tests {
             test.chunk.normalize();
             assert_eq!(test.chunk, test.want, "test `{}` failed", test.name);
         }
+    }
+
+    #[test]
+    fn test_trim_android_stacks() {
+        let art = |p: &str| Frame {
+            package: Some(p.to_string()),
+            ..Default::default()
+        };
+        let named = |f: &str| Frame {
+            function: Some(f.to_string()),
+            ..Default::default()
+        };
+
+        let sample = |stack_id: i32| Sample {
+            stack_id,
+            thread_id: "1".to_string(),
+            timestamp: 0.0,
+        };
+
+        let mut data = SampleData {
+            frames: vec![
+                named("app"),                                 // 0 -> 0
+                art("apex/com.android.art/lib64/libart.so"),  // 1 dropped
+                art("system/lib64/libhwui.so"),               // 2 -> 1 (not ART)
+                art("/apex/com.android.art/lib64/libart.so"), // 3 dropped
+                named("app2"),                                // 4 -> 2
+            ],
+            // Samples reference stacks by id, which trimming must not touch.
+            samples: vec![sample(0), sample(1), sample(2)],
+            stacks: vec![vec![0, 1, 2, 3, 4], vec![1, 3], vec![2]],
+            thread_metadata: None,
+        };
+
+        data.trim_android_stacks();
+
+        assert_eq!(
+            data.frames
+                .iter()
+                .map(|f| f.function.clone())
+                .collect::<Vec<_>>(),
+            vec![Some("app".to_string()), None, Some("app2".to_string())]
+        );
+        // ART frames vanish from stacks; the all-ART stack becomes empty.
+        assert_eq!(data.stacks, vec![vec![0, 1, 2], vec![], vec![1]]);
+        // Stack ids on samples are untouched.
+        assert_eq!(
+            data.samples.iter().map(|s| s.stack_id).collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[test]
+    fn test_trim_android_stacks_noop() {
+        let mut data = SampleData {
+            frames: vec![
+                Frame {
+                    function: Some("app".to_string()),
+                    ..Default::default()
+                },
+                Frame {
+                    package: Some("system/lib64/libhwui.so".to_string()),
+                    ..Default::default()
+                },
+            ],
+            samples: vec![],
+            stacks: vec![vec![0, 1]],
+            thread_metadata: None,
+        };
+
+        data.trim_android_stacks();
+
+        assert_eq!(data.frames.len(), 2);
+        assert_eq!(data.stacks, vec![vec![0, 1]]);
+    }
+
+    #[test]
+    fn test_trim_android_stacks_out_of_range_id_does_not_panic() {
+        // A malformed profile may reference a frame id that is out of range.
+        // Trimming must not panic; the stray reference is left in place for
+        // `call_trees` to reject as an invalid frame id.
+        let mut data = SampleData {
+            frames: vec![
+                Frame {
+                    function: Some("app".to_string()),
+                    ..Default::default()
+                },
+                Frame {
+                    package: Some("apex/com.android.art/lib64/libart.so".to_string()),
+                    ..Default::default()
+                },
+            ],
+            samples: vec![],
+            // id 2 and 99 are out of range; id 1 references the dropped ART frame.
+            stacks: vec![vec![0, 1, 2], vec![99]],
+            thread_metadata: None,
+        };
+
+        data.trim_android_stacks();
+
+        assert_eq!(data.frames.len(), 1);
+        // ART reference removed, in-range survivor kept, out-of-range ids preserved.
+        assert_eq!(data.stacks, vec![vec![0, 2], vec![99]]);
+    }
+
+    #[test]
+    fn test_normalize_only_trims_android() {
+        // A libart.so frame is synthetic on android, but the trimming is gated
+        // on the chunk platform: a non-android chunk must keep every frame.
+        let make_chunk = |platform: &str| SampleChunk {
+            platform: platform.to_string(),
+            profile: SampleData {
+                frames: vec![
+                    Frame {
+                        function: Some("app".to_string()),
+                        ..Default::default()
+                    },
+                    Frame {
+                        package: Some("apex/com.android.art/lib64/libart.so".to_string()),
+                        ..Default::default()
+                    },
+                ],
+                samples: vec![],
+                stacks: vec![vec![0, 1]],
+                thread_metadata: None,
+            },
+            ..Default::default()
+        };
+
+        let mut android = make_chunk("android");
+        android.normalize();
+        assert_eq!(android.profile.frames.len(), 1);
+        assert_eq!(android.profile.stacks, vec![vec![0]]);
+
+        let mut cocoa = make_chunk("cocoa");
+        cocoa.normalize();
+        assert_eq!(cocoa.profile.frames.len(), 2);
+        assert_eq!(cocoa.profile.stacks, vec![vec![0, 1]]);
     }
 }


### PR DESCRIPTION
Adds Android in-app frame classification and synthetic-frame trimming for
sample v2 profile chunks.

- **In-app classification** gated on `android` chunks.
  - Native frames are classified based on package location — `system/`, `vendor/`,
    `apex/`, `[vdso]`, `[stack]`, `[anon:dalvik-*]` are system.
  - JVM frames are classified by class namespace
    `java.`, `android.`, `kotlin.`, `sun.` and `io.sentry.` is treated as system,
    similar to how it's already done for e.g. python and cocoa.
  - Frames with no platform set, default to the profile (`"android"`) platform

- **Synthetic-frame trimming** in `SampleData::trim_android_stacks`, gated on
  the `android` chunk platform, mirroring sentry-java's `TombstoneParser`:
  - Drops ART runtime frames (`libart.so`) and unsymbolicatable anonymous VMA
    frames (`<anonymous…>` with no function name), similar to
    `SampleData::trim_python_stacks`

## Test plan

- Added tests including package/module classification,
  trust-relay-when-present vs. classify-when-absent, synthetic-frame detection,
  and stack re-indexing (noop, out-of-range, platform-gating cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
